### PR TITLE
Coverage: Allow unknown paths

### DIFF
--- a/lib/openapi_first/test_coverage.rb
+++ b/lib/openapi_first/test_coverage.rb
@@ -11,8 +11,8 @@ module OpenapiFirst
     end
 
     def call(env)
-      id = endpoint_id_for_request(Rack::Request.new(env))
-      @to_be_called.delete(id)
+      endpoint = endpoint_for_request(Rack::Request.new(env))
+      @to_be_called.delete(endpoint_id(endpoint)) if endpoint
       @app.call(env)
     end
 
@@ -22,11 +22,12 @@ module OpenapiFirst
       "#{endpoint.path.path}##{endpoint.method}"
     end
 
-    def endpoint_id_for_request(request)
-      endpoint = @spec
+    def endpoint_for_request(request)
+      @spec
         .path_by_path(request.path)
         .endpoint_by_method(request.request_method.downcase)
-      endpoint_id(endpoint)
+      rescue OasParser::PathNotFound => error
+        warn error.message
     end
   end
 end

--- a/spec/test_coverage_spec.rb
+++ b/spec/test_coverage_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OpenapiFirst::TestCoverage do
     app = ->(_env) { Rack::Response.new('hello') }
     described_class.new(app, spec)
   end
-  
+
   describe '#to_be_called' do
     it 'starts with all endpoints' do
       expected_endpoints = %w[/pets#get /pets#post /pets/{petId}#get]
@@ -23,6 +23,11 @@ RSpec.describe OpenapiFirst::TestCoverage do
       response = Rack::MockRequest.new(subject).get('/pets')
       expect(subject.to_be_called).to eq expected_endpoints
       expect(response.body).to eq 'hello' # make we called the original app
+    end
+
+    it 'allows paths unknown to the spec' do
+      response = Rack::MockRequest.new(subject).get('/hello')
+      expect(response.status).to eq 200
     end
   end
 end


### PR DESCRIPTION
Don't raise an exception in TestCoverage when calling an unkown path