### PR TITLE
Fix env being the default params value

### DIFF
--- a/lib/openapi_first/operation_resolver.rb
+++ b/lib/openapi_first/operation_resolver.rb
@@ -37,7 +37,7 @@ module OpenapiFirst
 
     def initialize(env)
       @env = env
-      super
+      super()
     end
   end
 end

--- a/spec/operation_resolver_spec.rb
+++ b/spec/operation_resolver_spec.rb
@@ -132,6 +132,26 @@ RSpec.describe OpenapiFirst::OperationResolver do
     end
 
     describe 'params' do
+      it 'behaves like a hash' do
+        params = OpenapiFirst::Params.new(:fake_env)
+
+        params.merge!(existing: :value)
+        params['existing'] = 'other_value'
+
+        expect(params[:existing]).to eq :value
+        expect(params['existing']).to eq 'other_value'
+      end
+
+      it 'returns nil on non-existant keys' do
+        params = OpenapiFirst::Params.new(:fake_env)
+        expect(params[:non_existing]).to be_nil
+      end
+
+      it 'has an env' do
+        params = OpenapiFirst::Params.new(:fake_env)
+        expect(params.env).to eq :fake_env
+      end
+
       it 'has allowed query string parameters' do
         expected_params = {
           'tags' => ['foo']


### PR DESCRIPTION
We found this "bug"/annoying behaviour while using this. 
When accesing a non-existant key in the params the whole env is returned which seems unintended & weird...
 
I added some tests for the hash-like behaviour of the params and fixed the weird default value...