### PR TITLE
Respect rack's env['SCRIPT_NAME'] in router

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
 AllCops:
   TargetRubyVersion: 2.6
-Documentation:
+Style/Documentation:
   Enabled: false
-BlockLength:
+Style/BlockLength:
   Exclude:
   - 'spec/**/*.rb'
   - '*.gemspec'

--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -16,12 +16,18 @@ module OpenapiFirst
     end
 
     def call(env)
+      original_path_info = env[Rack::PATH_INFO]
+      # Overwrite PATH_INFO temporarily, because hanami-router does not respect SCRIPT_NAME # rubocop:disable Layout/LineLength
+      env[Rack::PATH_INFO] = Rack::Request.new(env).path
+
       route = @router.recognize(env)
       return route.endpoint.call(env) if route.routable?
 
       return @parent_app.call(env) if @parent_app
 
       NOT_FOUND
+    ensure
+      env[Rack::PATH_INFO] = original_path_info
     end
 
     def find_handler(operation_id) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe OpenapiFirst::Router do
       expect(operation.operation_id).to eq 'listPets'
     end
 
+    # This is useful if the app is mounted via Syro or else
+    it 'respects SCRIPT_NAME do' do
+      env = Rack::MockRequest.env_for('/', method: :get)
+      env[Rack::SCRIPT_NAME] = '/pets'
+      env[Rack::PATH_INFO] = '/42'
+
+      app.call(env)
+      operation = env[OpenapiFirst::OPERATION]
+      expect(operation.operation_id).to eq 'showPetById'
+
+      expect(env[Rack::SCRIPT_NAME]).to eq '/pets'
+      expect(env[Rack::PATH_INFO]).to eq '/42'
+    end
+
     describe 'path parameters' do
       it 'adds path parameters to env ' do
         get '/pets/1'


### PR DESCRIPTION
env['SCRIPT_NAME'] is set when a rack app is "mounted" at a certain sub-path.
This should make it work when using OASF inside syro or the like.