### PR TITLE
Rename PARAMS to PARAMETERS, Params to Inbox

### DIFF
--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -13,7 +13,7 @@ require 'openapi_first/app'
 
 module OpenapiFirst
   OPERATION = 'openapi_first.operation'
-  PARAMS = 'openapi_first.params'
+  PARAMETERS = 'openapi_first.parameters'
   REQUEST_BODY = 'openapi_first.parsed_request_body'
   HANDLER = 'openapi_first.handler'
 

--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -5,6 +5,7 @@ require 'oas_parser/path' # TODO: Remove when Nexmo/oas_parser/pull/49 is merged
 require 'oas_parser'
 require 'openapi_first/definition'
 require 'openapi_first/version'
+require 'openapi_first/inbox'
 require 'openapi_first/router'
 require 'openapi_first/request_validation'
 require 'openapi_first/response_validator'
@@ -15,6 +16,7 @@ module OpenapiFirst
   OPERATION = 'openapi_first.operation'
   PARAMETERS = 'openapi_first.parameters'
   REQUEST_BODY = 'openapi_first.parsed_request_body'
+  INBOX = 'openapi_first.inbox'
   HANDLER = 'openapi_first.handler'
 
   def self.load(spec_path, only: nil)

--- a/lib/openapi_first/inbox.rb
+++ b/lib/openapi_first/inbox.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  # An instance of this gets passed to handler functions as first argument.
+  class Inbox < Hash
+    attr_reader :env
+
+    def initialize(env)
+      @env = env
+      super()
+    end
+  end
+end

--- a/lib/openapi_first/operation_resolver.rb
+++ b/lib/openapi_first/operation_resolver.rb
@@ -25,7 +25,7 @@ module OpenapiFirst
 
     def build_params(env)
       sources = [
-        env[PARAMS],
+        env[PARAMETERS],
         env[REQUEST_BODY]
       ].tap(&:compact!)
       Params.new(env).merge!(*sources)

--- a/lib/openapi_first/operation_resolver.rb
+++ b/lib/openapi_first/operation_resolver.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 require 'rack'
+require_relative 'inbox'
 
 module OpenapiFirst
   class OperationResolver
     def call(env)
       operation = env[OpenapiFirst::OPERATION]
       res = Rack::Response.new
-      params = build_params(env)
+      inbox = env[INBOX] = build_inbox(env)
       handler = env[HANDLER]
-      result = handler.call(params, res)
+      result = handler.call(inbox, res)
       res.write serialize(result) if result && res.body.empty?
       res[Rack::CONTENT_TYPE] ||= operation.content_type_for(res.status)
       res.finish
@@ -23,21 +24,12 @@ module OpenapiFirst
       MultiJson.dump(result)
     end
 
-    def build_params(env)
+    def build_inbox(env)
       sources = [
         env[PARAMETERS],
         env[REQUEST_BODY]
       ].tap(&:compact!)
-      Params.new(env).merge!(*sources)
-    end
-  end
-
-  class Params < Hash
-    attr_reader :env
-
-    def initialize(env)
-      @env = env
-      super()
+      Inbox.new(env).merge!(*sources)
     end
   end
 end

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -16,7 +16,7 @@ module OpenapiFirst
       return @app.call(env) unless operation
 
       catch(:halt) do
-        validate_query_parameters!(env, operation, env[PARAMS])
+        validate_query_parameters!(env, operation, env[PARAMETERS])
         req = Rack::Request.new(env)
         content_type = req.content_type
         return @app.call(env) unless operation.request_body
@@ -106,7 +106,7 @@ module OpenapiFirst
       if errors.any?
         halt error_response(400, serialize_query_parameter_errors(errors))
       end
-      env[PARAMS] = params
+      env[PARAMETERS] = params
     end
 
     def filtered_params(json_schema, params)

--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -84,7 +84,7 @@ module OpenapiFirst
           normalized_path,
           to: lambda do |env|
             env[OPERATION] = operation
-            env[PARAMS] = Utils.deep_stringify(env['router.params'])
+            env[PARAMETERS] = Utils.deep_stringify(env['router.params'])
             env[HANDLER] = handler
             @app.call(env)
           end

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe OpenapiFirst::Inbox do
+  it 'behaves like a hash' do
+    params = described_class.new(:fake_env)
+
+    params.merge!(existing: :value)
+    params['existing'] = 'other_value'
+
+    expect(params[:existing]).to eq :value
+    expect(params['existing']).to eq 'other_value'
+  end
+
+  it 'returns nil on non-existant keys' do
+    params = described_class.new(:fake_env)
+    expect(params[:non_existing]).to be_nil
+  end
+
+  it 'has an env' do
+    params = described_class.new(:fake_env)
+    expect(params.env).to eq :fake_env
+  end
+end

--- a/spec/operation_resolver_spec.rb
+++ b/spec/operation_resolver_spec.rb
@@ -132,24 +132,20 @@ RSpec.describe OpenapiFirst::OperationResolver do
     end
 
     describe 'params' do
-      it 'behaves like a hash' do
-        params = OpenapiFirst::Params.new(:fake_env)
+      it 'is also as INBOX in env' do
+        expect(MyApi).to receive(:find_pets) do |params, _res|
+          expect(params).to be params.env[OpenapiFirst::INBOX]
+        end
 
-        params.merge!(existing: :value)
-        params['existing'] = 'other_value'
-
-        expect(params[:existing]).to eq :value
-        expect(params['existing']).to eq 'other_value'
+        get '/pets', 'tags[]' => 'foo', 'foo' => 'bar'
       end
 
-      it 'returns nil on non-existant keys' do
-        params = OpenapiFirst::Params.new(:fake_env)
-        expect(params[:non_existing]).to be_nil
-      end
+      it 'is an instance of Inbox' do
+        expect(MyApi).to receive(:find_pets) do |params, _res|
+          expect(params).to be_a OpenapiFirst::Inbox
+        end
 
-      it 'has an env' do
-        params = OpenapiFirst::Params.new(:fake_env)
-        expect(params.env).to eq :fake_env
+        get '/pets', 'tags[]' => 'foo', 'foo' => 'bar'
       end
 
       it 'has allowed query string parameters' do

--- a/spec/parameter_validation_spec.rb
+++ b/spec/parameter_validation_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Parameter validation' do
     it 'adds filtered query parameters to env ' do
       get path, params
 
-      expect(last_request.env[OpenapiFirst::PARAMS]).to eq params
+      expect(last_request.env[OpenapiFirst::PARAMETERS]).to eq params
     end
 
     it 'skips parameter validation if no parameters are defined' do
@@ -94,12 +94,12 @@ RSpec.describe 'Parameter validation' do
       get path, params.merge(foo: 'bar')
 
       expect(last_response.status).to eq 200
-      expect(last_request.env[OpenapiFirst::PARAMS]).to eq params
+      expect(last_request.env[OpenapiFirst::PARAMETERS]).to eq params
     end
 
     describe 'type conversion' do
       def last_params
-        last_request.env[OpenapiFirst::PARAMS]
+        last_request.env[OpenapiFirst::PARAMETERS]
       end
 
       it 'converts to integer' do

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe OpenapiFirst::Router do
       it 'adds path parameters to env ' do
         get '/pets/1'
 
-        params = last_request.env[OpenapiFirst::PARAMS]
+        params = last_request.env[OpenapiFirst::PARAMETERS]
         expect(params).to eq('petId' => '1')
       end
 
@@ -119,7 +119,7 @@ RSpec.describe OpenapiFirst::Router do
         expect(Mustermann::Template).to_not receive(:new)
         get 'pets'
 
-        params = last_request.env[OpenapiFirst::PARAMS]
+        params = last_request.env[OpenapiFirst::PARAMETERS]
         expect(params).to be_empty
       end
     end
@@ -128,7 +128,7 @@ RSpec.describe OpenapiFirst::Router do
       it 'adds query parameters to env ' do
         get '/pets?limit=2'
 
-        params = last_request.env[OpenapiFirst::PARAMS]
+        params = last_request.env[OpenapiFirst::PARAMETERS]
         expect(params).to eq('limit' => '2')
       end
     end


### PR DESCRIPTION
"PARAMETERS", this is the same term used in OAS to describe query and path **parameters**.

"Inbox" are parameters and request body merged.

This is a breaking change if people rely on PARAMS 💔