### PR TITLE
Fill INBOX during request validation

### DIFF
--- a/lib/openapi_first/operation_resolver.rb
+++ b/lib/openapi_first/operation_resolver.rb
@@ -8,7 +8,7 @@ module OpenapiFirst
     def call(env)
       operation = env[OpenapiFirst::OPERATION]
       res = Rack::Response.new
-      inbox = env[INBOX] = build_inbox(env)
+      inbox = env[INBOX]
       handler = env[HANDLER]
       result = handler.call(inbox, res)
       res.write serialize(result) if result && res.body.empty?
@@ -22,14 +22,6 @@ module OpenapiFirst
       return result if result.is_a?(String)
 
       MultiJson.dump(result)
-    end
-
-    def build_inbox(env)
-      sources = [
-        env[PARAMETERS],
-        env[REQUEST_BODY]
-      ].tap(&:compact!)
-      Inbox.new(env).merge!(*sources)
     end
   end
 end

--- a/spec/operation_resolver_spec.rb
+++ b/spec/operation_resolver_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe OpenapiFirst::OperationResolver do
     end
 
     describe 'params' do
-      it 'is also as INBOX in env' do
+      it 'uses INBOX from env' do
         expect(MyApi).to receive(:find_pets) do |params, _res|
           expect(params).to be params.env[OpenapiFirst::INBOX]
         end

--- a/spec/parameter_validation_spec.rb
+++ b/spec/parameter_validation_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe 'Parameter validation' do
       expect(last_request.env[OpenapiFirst::PARAMETERS]).to eq params
     end
 
+    it 'updates INBOX' do
+      get path, params
+
+      expect(last_request.env[OpenapiFirst::INBOX]).to eq params
+    end
+
     it 'skips parameter validation if no parameters are defined' do
       get '/info', params
 

--- a/spec/request_body_validation_spec.rb
+++ b/spec/request_body_validation_spec.rb
@@ -69,6 +69,13 @@ RSpec.describe 'Request body validation' do
       expect(last_request.env[OpenapiFirst::REQUEST_BODY]).to eq request_body
     end
 
+    it 'updates INBOX' do
+      header Rack::CONTENT_TYPE, 'application/json'
+      post path, json_dump(request_body)
+
+      expect(last_request.env[OpenapiFirst::INBOX]).to eq request_body
+    end
+
     it 'returns 400 if request body is not valid' do
       request_body['attributes']['name'] = 43
       header Rack::CONTENT_TYPE, 'application/json'

--- a/spec/router/find_handler_spec.rb
+++ b/spec/router/find_handler_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'rack'
+require 'openapi_first/router'
+
+RSpec.describe OpenapiFirst::Router do
+  describe '#find_handler' do
+    let(:router) do
+      described_class.new(
+        nil,
+        spec: OpenapiFirst.load('./spec/data/petstore.yaml'),
+        namespace: Web
+      )
+    end
+
+    before do
+      stub_const(
+        'Web',
+        Module.new do
+          def self.some_method(_params, _res); end
+        end
+      )
+      stub_const(
+        'Web::Things',
+        Class.new do
+          def self.some_class_method(_params, _res); end
+        end
+      )
+      stub_const(
+        'Web::Things::Index',
+        Class.new do
+          def call(_params, _res); end
+        end
+      )
+      stub_const(
+        'Web::Things::Show',
+        Class.new do
+          def initialize(env); end
+
+          def call(_params, _res); end
+        end
+      )
+    end
+
+    let(:env) { double }
+    let(:params) { double(:params, env: env) }
+
+    it 'finds some_method' do
+      expect(Web).to receive(:some_method)
+      router.find_handler('some_method').call
+    end
+
+    it 'finds things.some_method' do
+      expect(Web::Things).to receive(:some_class_method)
+      router.find_handler('things.some_class_method').call
+    end
+
+    it 'finds things#index' do
+      expect_any_instance_of(Web::Things::Index).to receive(:call)
+      router.find_handler('things#index').call(params, double)
+    end
+
+    it 'finds things#show with initializer' do
+      handler = router.find_handler('things#show')
+      response = double
+      action = ->(params, res) {}
+      expect(Web::Things::Show).to receive(:new).with(env) { action }
+      expect(action).to receive(:call).with(params, response)
+      handler.call(params, response)
+    end
+
+    it 'does not find inherited constants' do
+      expect(router.find_handler('string.to_s')).to be_nil
+      expect(router.find_handler('::string.to_s')).to be_nil
+    end
+
+    it 'does not find nested constants' do
+      expect(router.find_handler('foo.bar.to_s')).to be_nil
+      expect(router.find_handler('::foo::baz.to_s')).to be_nil
+    end
+  end
+end

--- a/spec/router/middleware_spec.rb
+++ b/spec/router/middleware_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'spec_helper'
+require_relative '../spec_helper'
 require 'rack'
 require 'rack/test'
 require 'openapi_first/router'
@@ -145,82 +145,6 @@ RSpec.describe OpenapiFirst::Router do
           }
         end
       end
-    end
-  end
-
-  describe '#find_handler' do
-    let(:router) do
-      described_class.new(
-        nil,
-        spec: OpenapiFirst.load('./spec/data/petstore.yaml'),
-        namespace: Web
-      )
-    end
-
-    before do
-      stub_const(
-        'Web',
-        Module.new do
-          def self.some_method(_params, _res); end
-        end
-      )
-      stub_const(
-        'Web::Things',
-        Class.new do
-          def self.some_class_method(_params, _res); end
-        end
-      )
-      stub_const(
-        'Web::Things::Index',
-        Class.new do
-          def call(_params, _res); end
-        end
-      )
-      stub_const(
-        'Web::Things::Show',
-        Class.new do
-          def initialize(env); end
-
-          def call(_params, _res); end
-        end
-      )
-    end
-
-    let(:env) { double }
-    let(:params) { double(:params, env: env) }
-
-    it 'finds some_method' do
-      expect(Web).to receive(:some_method)
-      router.find_handler('some_method').call
-    end
-
-    it 'finds things.some_method' do
-      expect(Web::Things).to receive(:some_class_method)
-      router.find_handler('things.some_class_method').call
-    end
-
-    it 'finds things#index' do
-      expect_any_instance_of(Web::Things::Index).to receive(:call)
-      router.find_handler('things#index').call(params, double)
-    end
-
-    it 'finds things#show with initializer' do
-      handler = router.find_handler('things#show')
-      response = double
-      action = ->(params, res) {}
-      expect(Web::Things::Show).to receive(:new).with(env) { action }
-      expect(action).to receive(:call).with(params, response)
-      handler.call(params, response)
-    end
-
-    it 'does not find inherited constants' do
-      expect(router.find_handler('string.to_s')).to be_nil
-      expect(router.find_handler('::string.to_s')).to be_nil
-    end
-
-    it 'does not find nested constants' do
-      expect(router.find_handler('foo.bar.to_s')).to be_nil
-      expect(router.find_handler('::foo::baz.to_s')).to be_nil
     end
   end
 end


### PR DESCRIPTION
This is useful if you decide to only use the request validation middleware,
but not the resolver middleware