### PR TITLE
Don't require intermediate objects multiple times

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (0.10.0)
+    openapi_first (0.10.1)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.alpha2)
       hanami-utils (~> 2.0.alpha1)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (0.10.0)
+    openapi_first (0.10.1)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.alpha2)
       hanami-utils (~> 2.0.alpha1)

--- a/lib/openapi_first/operation.rb
+++ b/lib/openapi_first/operation.rb
@@ -46,9 +46,10 @@ module OpenapiFirst
       end
     end
 
-    def generate_schema(schema, params, parameter)
+    def generate_schema(schema, params, parameter) # rubocop:disable Metrics/MethodLength
+      required = Set.new(schema['required'])
       params.each do |key, value|
-        schema['required'] << key if parameter.required
+        required << key if parameter.required
         if value.is_a? Hash
           property_schema = new_node
           generate_schema(property_schema, value, parameter)
@@ -57,6 +58,7 @@ module OpenapiFirst
           schema['properties'][key] = parameter.schema
         end
       end
+      schema['required'] = required.to_a
     end
 
     def new_node

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 end

--- a/spec/data/parameters-flat.yaml
+++ b/spec/data/parameters-flat.yaml
@@ -30,6 +30,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: filter[id]
+          in: query
+          required: true
+          schema:
+            type: integer
         - name: filter[other]
           in: query
           required: false

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -67,10 +67,13 @@ RSpec.describe OpenapiFirst::Operation do
             },
             'filter' => {
               'type' => 'object',
-              'required' => ['tag'],
+              'required' => %w[tag id],
               'properties' => {
                 'tag' => {
                   'type' => 'string'
+                },
+                'id' => {
+                  'type' => 'integer'
                 },
                 'other' => {
                   'type' => 'string'

--- a/spec/request_validation/parameter_validation_spec.rb
+++ b/spec/request_validation/parameter_validation_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Parameter validation' do
       let(:params) do
         {
           'term' => 'Oscar',
-          'filter' => { 'tag' => 'dogs', 'other' => 'things' }
+          'filter' => { 'tag' => 'dogs', 'id' => '1', 'other' => 'things' }
         }
       end
 


### PR DESCRIPTION
When generating the JSON Schema for parameters, don't generate `require: ['filter',
   'filter']` , but just `require: ['filter']`