### PR TITLE
Add `raise` and `not_found` options to Router middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add `raise` option to Router middleware to raise an error if request could not be found in the API description similar to committee's raise option.
+
 ## 0.10.2
 - Return 400 if request body has invalid JSON ([issue](https://github.com/ahx/openapi_first/issues/73)) thanks Thomas Frütel
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,17 @@ Start with writing an OpenAPI file that describes the API, which you are about t
 ## Rack middlewares
 OpenapiFirst consists of these Rack middlewares:
 
-- `OpenapiFirst::Router` finds the operation for the current request or returns 404 if no operation was found.
-- `OpenapiFirst::RequestValidation` validates the request against the found operation and returns 400 if the request is invalid.
+- `OpenapiFirst::Router` – Finds the operation for the current request or returns 404 if no operation was found. This can be customized.
+- `OpenapiFirst::RequestValidation` – Validates the request against the API description and returns 400 if the request is invalid.
 - `OpenapiFirst::OperationResolver` calls the [handler](#handlers) found for the operation.
 
-### OpenapiFirst::Router
+## OpenapiFirst::Router
 Options and their defaults:
 
 | Name | Possible values | Description | Default
 |:---|---|---|---|
-| `not_found:` |`nil`, `:continue`, `Proc`| Specifies what to do if path was not found in the API description. `:continue` does nothing an calls the next app, `nil` returns a 404 response, can also be `Proc` (or something that responds to `call`) to customize the response. | nil
+| `not_found:` |`nil`, `:continue`, `Proc`| Specifies what to do if path was not found in the API description. `nil` (default) returns a 404 response. `:continue` does nothing an calls the next app. `Proc` (or something that responds to `call`) to customize the response. | `nil` (return 404)
+| `raise:` |`false`, `true` | If set to true the middleware raises `OpenapiFirst::NotFoundError` when a path or method was not found in the API description. This is useful during testing to spot an incomplete API description. | `false` (don't raise an exception)
 |
 
 ## Usage within your Rack webframework
@@ -32,6 +33,7 @@ These variables will available in your rack env:
 
 - `env[OpenapiFirst::OPERATION]` - Holds an Operation object that responsed about `operation_id` and `path`. This is useful for introspection.
 - `env[OpenapiFirst::INBOX]`. Holds the (filtered) path and query parameters and the parsed request body.
+
 
 ## Standalone usage
 You can implement your API in conveniently with just OpenapiFirst.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ OpenapiFirst consists of these Rack middlewares:
 - `OpenapiFirst::RequestValidation` validates the request against the found operation and returns 400 if the request is invalid.
 - `OpenapiFirst::OperationResolver` calls the [handler](#handlers) found for the operation.
 
+### OpenapiFirst::Router
+Options and their defaults:
+
+| Name | Possible values | Description | Default
+|:---|---|---|---|
+| `not_found:` |`nil`, `:continue`, `Proc`| Specifies what to do if path was not found in the API description. `:continue` does nothing an calls the next app, `nil` returns a 404 response, can also be `Proc` (or something that responds to `call`) to customize the response. | nil
+|
+
 ## Usage within your Rack webframework
 If you just want to use the request validation part without any handlers you can use the rack middlewares standalone:
 

--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -48,5 +48,6 @@ module OpenapiFirst
   end
 
   class Error < StandardError; end
-  class ResponseCodeNotFoundError < Error; end
+  class NotFoundError < Error; end
+  class ResponseCodeNotFoundError < NotFoundError; end
 end

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -4,7 +4,10 @@ require_relative 'operation'
 
 module OpenapiFirst
   class Definition
+    attr_reader :filepath
+
     def initialize(parsed)
+      @filepath = parsed.path
       @spec = parsed
     end
 

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe OpenapiFirst::Definition do
       expect(definition.operations.map(&:operation_id)).to eq expected_ids
     end
   end
+
+  describe '#filepath' do
+    it 'returns the path of the file' do
+      definition = OpenapiFirst.load('./spec/data/petstore.yaml')
+      expect(definition.filepath).to eq './spec/data/petstore.yaml'
+    end
+  end
 end

--- a/spec/router/middleware_spec.rb
+++ b/spec/router/middleware_spec.rb
@@ -160,6 +160,58 @@ RSpec.describe OpenapiFirst::Router do
       end
     end
 
+    describe('raise option') do
+      let(:app) do
+        val = option
+        Rack::Builder.new do
+          use OpenapiFirst::Router,
+              spec: OpenapiFirst.load('./spec/data/petstore.yaml'),
+              raise: val
+          run lambda { |_env|
+            Rack::Response.new('hello', 200).finish
+          }
+        end
+      end
+
+      describe('with nil') do
+        let(:option) { nil }
+
+        it 'returns 404' do
+          get '/unknown'
+
+          expect(last_response.status).to eq 404
+        end
+      end
+
+      describe('with false') do
+        let(:option) { nil }
+
+        it 'returns 404' do
+          get '/unknown'
+
+          expect(last_response.status).to eq 404
+        end
+      end
+
+      describe('with true') do
+        let(:option) { :raise }
+
+        it 'raises an error if path was not found' do
+          msg = "Could not find definition for GET '/unknown' in API description ./spec/data/petstore.yaml" # rubocop:disable Layout/LineLength
+          expect do
+            get '/unknown'
+          end.to raise_error OpenapiFirst::NotFoundError, msg
+        end
+
+        it 'raises an error if request method was not found' do
+          msg = "Could not find definition for DELETE '/pets' in API description ./spec/data/petstore.yaml" # rubocop:disable Layout/LineLength
+          expect do
+            delete '/pets'
+          end.to raise_error OpenapiFirst::NotFoundError, msg
+        end
+      end
+    end
+
     describe('not_found option') do
       let(:app) do
         val = option


### PR DESCRIPTION
raise - Raise an error if request could not be found in the API description.
not_found - Ignore undefined requests or customize the response