### PR TITLE
Add `raise_error` option to RequestValidation middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## Unreleased (0.12.x)
 - Rename `raise` option to `raise_error`
 - Add `raise_error` option to RequestValidation middleware
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Rename `raise` option to `raise_error`
+- Add `raise_error` option to RequestValidation middleware
+
 ## 0.11.0
 - Raise error if you forgot to add the Router middleware
 - Make OpenapiFirst.app raise an error in test env when request path is not specified

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (0.11.0)
+    openapi_first (0.12.0.alpha1)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.alpha3)
       hanami-utils (~> 2.0.alpha1)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options and their defaults:
 |:---|---|---|---|
 |`spec:`| | The spec loaded via `OpenapiFirst.load` ||
 | `not_found:` |`nil`, `:continue`, `Proc`| Specifies what to do if the path was not found in the API description. `nil` (default) returns a 404 response. `:continue` does nothing an calls the next app. `Proc` (or something that responds to `call`) to customize the response. | `nil` (return 404)
-| `raise:` |`false`, `true` | If set to true the middleware raises `OpenapiFirst::NotFoundError` when a path or method was not found in the API description. This is useful during testing to spot an incomplete API description. | `false` (don't raise an exception)
+| `raise_error:` |`false`, `true` | If set to true the middleware raises `OpenapiFirst::NotFoundError` when a path or method was not found in the API description. This is useful during testing to spot an incomplete API description. | `false` (don't raise an exception)
 
 ## OpenapiFirst::RequestValidation
 
@@ -40,6 +40,13 @@ This middleware returns a 400 status code with a body that describes the error i
 ```ruby
 use OpenapiFirst::RequestValidation
 ```
+
+
+Options and their defaults:
+
+| Name | Possible values | Description | Default
+|:---|---|---|---|
+| `raise_error:` |`false`, `true` | If set to true the middleware raises `OpenapiFirst::RequestInvalidError` instead of returning 4xx. | `false` (don't raise an exception)
 
 The error responses conform with [JSON:API](https://jsonapi.org).
 
@@ -117,7 +124,7 @@ There are two ways to set the response body:
 - Returning a value which will get converted to JSON
 
 ## OpenapiFirst::ResponseValidation
-This middleware is especially useful when testing. It raises an error if the response is not valid.
+This middleware is especially useful when testing. It *always* raises an error if the response is not valid.
 
 ```ruby
 use OpenapiFirst::ResponseValidation if ENV['RACK_ENV'] == 'test'

--- a/lib/openapi_first/app.rb
+++ b/lib/openapi_first/app.rb
@@ -5,11 +5,11 @@ require 'logger'
 
 module OpenapiFirst
   class App
-    def initialize(parent_app, spec, namespace:, router_raise:)
+    def initialize(parent_app, spec, namespace:, raise_error:)
       @stack = Rack::Builder.app do
         freeze_app
-        use OpenapiFirst::Router, spec: spec, raise: router_raise, parent_app: parent_app
-        use OpenapiFirst::RequestValidation
+        use OpenapiFirst::Router, spec: spec, raise_error: raise_error, parent_app: parent_app
+        use OpenapiFirst::RequestValidation, raise_error: raise_error
         run OpenapiFirst::Responder.new(
           spec: spec,
           namespace: namespace

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -11,8 +11,9 @@ module OpenapiFirst
   class RequestValidation # rubocop:disable Metrics/ClassLength
     prepend RouterRequired
 
-    def initialize(app)
+    def initialize(app, raise_error: false)
       @app = app
+      @raise = raise_error
     end
 
     def call(env) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -85,6 +86,8 @@ module OpenapiFirst
     end
 
     def error_response(status, errors = [default_error(status)])
+      raise RequestInvalidError, errors if @raise
+
       Rack::Response.new(
         MultiJson.dump(errors: errors),
         status,

--- a/lib/openapi_first/response_validator.rb
+++ b/lib/openapi_first/response_validator.rb
@@ -9,7 +9,7 @@ module OpenapiFirst
   class ResponseValidator
     def initialize(spec)
       @spec = spec
-      @router = Router.new(->(_env) {}, spec: spec, raise: true)
+      @router = Router.new(->(_env) {}, spec: spec, raise_error: true)
     end
 
     def validate(request, response)

--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -9,16 +9,21 @@ module OpenapiFirst
     NOT_FOUND = Rack::Response.new('', 404).finish.freeze
     DEFAULT_NOT_FOUND_APP = ->(_env) { NOT_FOUND }
 
-    def initialize(app, options) # rubocop:disable Metrics/MethodLength
+    def initialize(
+      app,
+      spec:,
+      raise_error: false,
+      parent_app: nil,
+      not_found: nil
+    )
       @app = app
-      @parent_app = options.fetch(:parent_app, nil)
-      @raise = options.fetch(:raise, false)
-      @failure_app = find_failure_app(options[:not_found])
+      @parent_app = parent_app
+      @raise = raise_error
+      @failure_app = find_failure_app(not_found)
       if @failure_app.nil?
         raise ArgumentError,
               'not_found must be nil, :continue or must respond to call'
       end
-      spec = options.fetch(:spec)
       @filepath = spec.filepath
       @router = build_router(spec.operations)
     end

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '0.11.0'
+  VERSION = '0.12.0.alpha1'
 end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -155,13 +155,13 @@ RSpec.describe OpenapiFirst::Router do
       end
     end
 
-    describe('raise option') do
+    describe('raise_error option') do
       let(:app) do
         val = option
         Rack::Builder.new do
           use OpenapiFirst::Router,
               spec: OpenapiFirst.load('./spec/data/petstore.yaml'),
-              raise: val
+              raise_error: val
           run lambda { |_env|
             Rack::Response.new('hello', 200).finish
           }


### PR DESCRIPTION
This makes the RequestValidation middleware usable just like the one from committee

Also rename `raise` option to `raise_error`

