### PR TITLE
Simpler handling for readOnly/writeOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Unreleased
-- Properties with `readOnly: true` are remove from request bodies during request validation.
-- An error is raised if response body includes a property with `writeOnly: true`.
+- Request validation fails if request includes a property with `readOnly: true`
+- Response validation fails if response body includes a property with `writeOnly: true`
 
 ## 0.13.2
 - Return indicator (`source: { parameter: 'list/1' }`) in error response body when array item in query parameter is invalid

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ tbd.
 
 ### readOnly / writeOnly properties
 
-Properties marked with `readOnly: true` are _ignored_ in all write requests (POST, PUT, PATCH, DELETE) during request validation and are removed from the request body.
+Request validation fails if request includes a property with `readOnly: true`.
 
-Properties marked with `writeOnly: true` are must not appear in response bodies and an error is raised during response validation if they do.
+Response validation fails if response body includes a property with `writeOnly: true`.
 
 ## OpenapiFirst::Responder
 

--- a/lib/openapi_first/schema_validation.rb
+++ b/lib/openapi_first/schema_validation.rb
@@ -9,36 +9,17 @@ module OpenapiFirst
 
     def initialize(schema, write: true)
       @raw_schema = schema
-      before_validation_hooks = []
-      before_validation_hooks << SKIP_READ_ONLY if write
-      before_validation_hooks << RAISE_WRITE_ONLY unless write
+      custom_keywords = {}
+      custom_keywords['writeOnly'] = proc { |data| !data } unless write
+      custom_keywords['readOnly'] = proc { |data| !data } if write
       @schemer = JSONSchemer.schema(
         schema,
-        before_property_validation: before_validation_hooks
+        keywords: custom_keywords
       )
     end
 
     def validate(input)
       @schemer.validate(input)
     end
-
-    SKIP_READ_ONLY = lambda do |data, property, property_schema, schema|
-      return unless property_schema['readOnly']
-
-      schema['required']&.delete(property)
-      data.delete(property) if data.key?(property) && property_schema.is_a?(Hash)
-    end
-    private_constant :SKIP_READ_ONLY
-
-    RAISE_WRITE_ONLY = lambda do |data, property, property_schema, schema|
-      if property_schema['writeOnly']
-        schema['required']&.delete(property)
-        if data.key?(property)
-          message = "write-only field '#{property}' appears in response body!"
-          raise OpenapiFirst::ResponseBodyInvalidError, message
-        end
-      end
-    end
-    private_constant :RAISE_WRITE_ONLY
   end
 end

--- a/lib/openapi_first/validation_format.rb
+++ b/lib/openapi_first/validation_format.rb
@@ -6,6 +6,7 @@ module OpenapiFirst
 
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/PerceivedComplexity
     def self.error_details(error)
       if error['type'] == 'pattern'
         {
@@ -16,6 +17,14 @@ module OpenapiFirst
         missing_keys = error['details']['missing_keys']
         {
           title: "is missing required properties: #{missing_keys.join(', ')}"
+        }
+      elsif error['type'] == 'readOnly'
+        {
+          title: 'appears in request, but is read-only'
+        }
+      elsif error['type'] == 'writeOnly'
+        {
+          title: 'write-only field appears in response:'
         }
       elsif SIMPLE_TYPES.include?(error['type'])
         {
@@ -29,5 +38,6 @@ module OpenapiFirst
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/spec/request_validation/request_body_validation_spec.rb
+++ b/spec/request_validation/request_body_validation_spec.rb
@@ -186,26 +186,15 @@ RSpec.describe 'Request body validation' do
         end
       end
 
-      it 'skips validation of required readOnly fields for write requests' do
+      it 'fails if request includes readOnly field' do
         header Rack::CONTENT_TYPE, 'application/json'
         request_body = {
-          name: 'foo'
+          name: 'foo',
+          id: '123'
         }
-        post '/test', json_dump(request_body)
-        expect(last_response.status).to be 200
-      end
-
-      it 'removes readOnly fields from request bodies for write requests' do
-        header Rack::CONTENT_TYPE, 'application/json'
-        request_body = {
-          id: 'ignoreme',
-          name: 'foo'
-        }
-        post '/test', json_dump(request_body)
-
-        expect(last_response.status).to be 200
-        expected_req_body = { name: 'foo' }
-        expect(last_request.env[OpenapiFirst::REQUEST_BODY]).to eq expected_req_body
+        expect do
+          post '/test', json_dump(request_body)
+        end.to raise_error OpenapiFirst::RequestInvalidError, 'Request body invalid: /id appears in request, but is read-only' # rubocop:disable Layout/LineLength
       end
     end
 

--- a/spec/response_validation_spec.rb
+++ b/spec/response_validation_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe OpenapiFirst::ResponseValidation do
       end
 
       it 'raises an error' do
-        message = "write-only field 'password' appears in response body!"
+        message = 'write-only field appears in response: /password'
         expect do
           post '/test', json_dump({ name: 'hans', password: 'admin' })
         end.to raise_error OpenapiFirst::ResponseBodyInvalidError, message


### PR DESCRIPTION
- Request validation fails if request includes a property with `readOnly: true`
- Response validation fails if response body includes a property with `writeOnly: true`