### PR TITLE
Parse boolean query params case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.4
+- Ignore case and whitespace when parsing boolen query parameters ('True', 'true')
+
+
 ## 0.13.3
 - Better error message if string does not match format
 - readOnly and writeOnly just works when used inside allOf

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -161,7 +161,7 @@ module OpenapiFirst
     end
 
     def to_boolean(value)
-      value = value.strip
+      value = value&.strip&.downcase
       return true if value == 'true'
       return false if value == 'false'
 

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -161,6 +161,7 @@ module OpenapiFirst
     end
 
     def to_boolean(value)
+      value = value.strip
       return true if value == 'true'
       return false if value == 'false'
 

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '0.13.3'
+  VERSION = '0.13.4'
 end

--- a/spec/request_validation/parameter_validation_spec.rb
+++ b/spec/request_validation/parameter_validation_spec.rb
@@ -263,6 +263,10 @@ RSpec.describe 'Parameter validation' do
         expect(last_response.status).to eq(200), last_response.body
         expect(last_params[:starred]).to eq true
 
+        get path, params.merge(starred: 'true ')
+        expect(last_response.status).to eq(200), last_response.body
+        expect(last_params[:starred]).to eq true
+
         get path, params.merge(starred: 'false')
         expect(last_response.status).to eq(200), last_response.body
         expect(last_params[:starred]).to eq false

--- a/spec/request_validation/parameter_validation_spec.rb
+++ b/spec/request_validation/parameter_validation_spec.rb
@@ -263,10 +263,6 @@ RSpec.describe 'Parameter validation' do
         expect(last_response.status).to eq(200), last_response.body
         expect(last_params[:starred]).to eq true
 
-        get path, params.merge(starred: 'true ')
-        expect(last_response.status).to eq(200), last_response.body
-        expect(last_params[:starred]).to eq true
-
         get path, params.merge(starred: 'false')
         expect(last_response.status).to eq(200), last_response.body
         expect(last_params[:starred]).to eq false
@@ -274,6 +270,22 @@ RSpec.describe 'Parameter validation' do
         get path, params.merge(starred: 'wrong')
         expect(last_response.status).to eq(400)
         expect(last_params[:starred]).to eq 'wrong'
+      end
+
+      it 'strips whitespace from booleans' do
+        get path, params.merge(starred: 'true ')
+        expect(last_response.status).to eq(200), last_response.body
+        expect(last_params[:starred]).to eq true
+      end
+
+      it 'parses booleans case insensitive' do
+        get path, params.merge(starred: 'True')
+        expect(last_response.status).to eq(200), last_response.body
+        expect(last_params[:starred]).to eq true
+
+        get path, params.merge(starred: 'fAlse')
+        expect(last_response.status).to eq(200), last_response.body
+        expect(last_params[:starred]).to eq false
       end
 
       it 'converts nested params' do


### PR DESCRIPTION
This allows `?myboolean=true` and `?myboolean=True`