### PR TITLE
WIP: Intepret empty array query parameter as empty array

### DIFF
--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -113,7 +113,7 @@ module OpenapiFirst
       env[INBOX].merge! params
     end
 
-    def filtered_params(json_schema, params)
+    def filtered_and_parsed_params(json_schema, params)
       json_schema['properties']
         .each_with_object({}) do |key_value, result|
           parameter_name = key_value[0].to_sym
@@ -135,7 +135,7 @@ module OpenapiFirst
     end
 
     def parse_parameter(value, schema)
-      return filtered_params(schema, value) if schema['properties']
+      return filtered_and_parsed_params(schema, value) if schema['properties']
 
       return parse_array_parameter(value, schema) if schema['type'] == 'array'
 
@@ -143,7 +143,8 @@ module OpenapiFirst
     end
 
     def parse_array_parameter(value, schema)
-      return value if value.nil? || value.empty?
+      return if value.nil?
+      return [] if value.empty?
 
       array = value.is_a?(Array) ? value : value.split(',')
       return array unless schema['items']

--- a/spec/request_validation/parameter_validation_spec.rb
+++ b/spec/request_validation/parameter_validation_spec.rb
@@ -163,6 +163,14 @@ RSpec.describe 'Parameter validation' do
           expect(parsed_parameters[:integers]).to eq [2, 3, 4]
         end
 
+        it 'interprets an empty value as an empty array' do
+          get '/default-style?strings=&integers='
+          expect(last_response.status).to eq(200), last_response.body
+          parsed_parameters = last_request.env[OpenapiFirst::PARAMETERS]
+          expect(parsed_parameters[:strings]).to eq []
+          expect(parsed_parameters[:integers]).to eq []
+        end
+
         it 'parses nested array' do
           params = {
             nested: { integers: '2,3,4' }
@@ -255,11 +263,11 @@ RSpec.describe 'Parameter validation' do
         expect(error[:title]).to eq 'is not valid: nil'
       end
 
-      it 'returns 400 if non-required array parameter is empty' do
+      it 'returns 200 if non-required array parameter is empty' do
         get "#{path}?term=Oscar&filter[id]=1&filter[tag]=&filter[other]=things"
-        expect(last_response.status).to eq 400
-        error = response_body[:errors][0]
-        expect(error[:title]).to eq 'is not valid: ""'
+        expect(last_response.status).to eq 200
+        parsed_parameters = last_request.env[OpenapiFirst::PARAMETERS]
+        expect(parsed_parameters.dig(:filter, :tag)).to eq []
       end
 
       it 'passes if query parameters are valid' do


### PR DESCRIPTION
When a query parameter is described as an array and the request is something like `?list=` we want the value to be parsed as an empty array ([]) instead of nil.