### PR TITLE
Populate default parameter values

### DIFF
--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -105,8 +105,10 @@ module OpenapiFirst
       return unless schema
 
       params = filtered_params(schema.raw_schema, params)
-      errors = schema.validate(Utils.deep_stringify(params))
+      params = Utils.deep_stringify(params)
+      errors = schema.validate(params)
       halt_with_error(400, serialize_query_parameter_errors(errors)) if errors.any?
+      params = Utils.deep_symbolize(params)
       env[PARAMETERS] = params
       env[INBOX].merge! params
     end

--- a/lib/openapi_first/schema_validation.rb
+++ b/lib/openapi_first/schema_validation.rb
@@ -14,6 +14,7 @@ module OpenapiFirst
       @schemer = JSONSchemer.schema(
         schema,
         keywords: custom_keywords,
+        insert_property_defaults: true,
         before_property_validation: proc do |data, property, property_schema, parent|
           convert_nullable(data, property, property_schema, parent)
         end

--- a/spec/data/search.yaml
+++ b/spec/data/search.yaml
@@ -42,10 +42,10 @@ paths:
         - name: limit
           in: query
           description: How many items to return at one time (max 100)
-          required: false
           schema:
             type: integer
             format: int32
+            default: 10
         - name: weight
           in: query
           description: An arbitrary parameter to test conversion to floats

--- a/spec/request_validation/parameter_validation_spec.rb
+++ b/spec/request_validation/parameter_validation_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe 'Parameter validation' do
       }
     end
 
+    let(:params_with_defaults) do
+      {
+        term: 'Oscar',
+        limit: 10
+      }
+    end
+
     let(:response_body) do
       json_load(last_response.body, symbolize_keys: true)
     end
@@ -112,13 +119,13 @@ RSpec.describe 'Parameter validation' do
     it 'adds filtered query parameters to env ' do
       get path, params
 
-      expect(last_request.env[OpenapiFirst::PARAMETERS]).to eq params
+      expect(last_request.env[OpenapiFirst::PARAMETERS]).to eq params_with_defaults
     end
 
     it 'updates INBOX' do
       get path, params
 
-      expect(last_request.env[OpenapiFirst::INBOX]).to eq params
+      expect(last_request.env[OpenapiFirst::INBOX]).to eq params_with_defaults
     end
 
     it 'skips parameter validation if no parameters are defined' do
@@ -137,7 +144,7 @@ RSpec.describe 'Parameter validation' do
       get path, params.merge(foo: 'bar')
 
       expect(last_response.status).to eq 200
-      expect(last_request.env[OpenapiFirst::PARAMETERS]).to eq params
+      expect(last_request.env[OpenapiFirst::PARAMETERS]).to eq params_with_defaults
     end
 
     describe 'with array query parameters' do


### PR DESCRIPTION
When doing request validation one would expect default parameter values
to be populated. Otherwise defaults would have to be populated inside
the application logic, not taking advantage of the OpenAPI specification