### PR TITLE
Use a Hash instead of named arguments for middleware options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use a Hash instead of named arguments for middleware options for better compatibility
+
 ## 0.15.0
 
 - Populate default parameter values

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (0.15.0)
+    openapi_first (0.16.0.beta1)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.alpha5)
       hanami-utils (~> 2.0.alpha3)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (0.15.0)
+    openapi_first (0.16.0.beta1)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.alpha5)
       hanami-utils (~> 2.0.alpha3)

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -10,9 +10,9 @@ module OpenapiFirst
   class RequestValidation # rubocop:disable Metrics/ClassLength
     prepend RouterRequired
 
-    def initialize(app, raise_error: false)
+    def initialize(app, options = {})
       @app = app
-      @raise = raise_error
+      @raise = options.fetch(:raise_error, false)
     end
 
     def call(env) # rubocop:disable Metrics/AbcSize

--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -7,15 +7,13 @@ module OpenapiFirst
   class Router
     def initialize(
       app,
-      spec:,
-      raise_error: false,
-      not_found: :halt,
-      parent_app: nil
+      options
     )
       @app = app
-      @parent_app = parent_app
-      @raise = raise_error
-      @not_found = not_found
+      @parent_app = options.fetch(:parent_app, nil)
+      @raise = options.fetch(:raise_error, false)
+      @not_found = options.fetch(:not_found, :halt)
+      spec = options.fetch(:spec)
       @filepath = spec.filepath
       @router = build_router(spec.operations)
     end

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '0.15.0'
+  VERSION = '0.16.0.beta1'
 end


### PR DESCRIPTION
To be compatible with hanami-api. Related to https://github.com/hanami/api/issues/33

TODO: Make is as safe as using named arguments. Is there a standard that says we should use a hash?