### PR TITLE
Revert "Use a Hash instead of named arguments for middleware options"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- Use a Hash instead of named arguments for middleware options for better compatibility
-
 ## 0.15.0
 
 - Populate default parameter values

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (0.16.0.beta1)
+    openapi_first (0.15.0)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.alpha5)
       hanami-utils (~> 2.0.alpha3)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (0.16.0.beta1)
+    openapi_first (0.15.0)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.alpha5)
       hanami-utils (~> 2.0.alpha3)

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -10,9 +10,9 @@ module OpenapiFirst
   class RequestValidation # rubocop:disable Metrics/ClassLength
     prepend RouterRequired
 
-    def initialize(app, options = {})
+    def initialize(app, raise_error: false)
       @app = app
-      @raise = options.fetch(:raise_error, false)
+      @raise = raise_error
     end
 
     def call(env) # rubocop:disable Metrics/AbcSize

--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -7,13 +7,15 @@ module OpenapiFirst
   class Router
     def initialize(
       app,
-      options
+      spec:,
+      raise_error: false,
+      not_found: :halt,
+      parent_app: nil
     )
       @app = app
-      @parent_app = options.fetch(:parent_app, nil)
-      @raise = options.fetch(:raise_error, false)
-      @not_found = options.fetch(:not_found, :halt)
-      spec = options.fetch(:spec)
+      @parent_app = parent_app
+      @raise = raise_error
+      @not_found = not_found
       @filepath = spec.filepath
       @router = build_router(spec.operations)
     end

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '0.16.0.beta1'
+  VERSION = '0.15.0'
 end


### PR DESCRIPTION
Let's move this to an "unstable" branch

Reverts ahx/openapi_first#130