### PR TITLE
Fix request validation failure when headers are present

### DIFF
--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -101,7 +101,7 @@ module OpenapiFirst
     end
 
     def validate_query_parameters!(operation, params)
-      schema = operation.parameters_schema
+      schema = operation.query_parameters_schema
       return unless schema
 
       params = filtered_params(schema.raw_schema, params)

--- a/spec/data/parameters-flat.yaml
+++ b/spec/data/parameters-flat.yaml
@@ -61,6 +61,12 @@ paths:
           schema:
             type: string
             pattern: (parents|children)+(,(parents|children))*
+        - name: header
+          in: header
+          description: A request header
+          schema:
+            type: string
+
       responses:
         "200":
           description: A paged array of pets

--- a/spec/data/parameters.yaml
+++ b/spec/data/parameters.yaml
@@ -58,6 +58,11 @@ paths:
           schema:
             type: string
             pattern: (parents|children)+(,(parents|children))*
+        - name: header
+          in: header
+          description: A request header
+          schema:
+            type: string
       responses:
         "200":
           description: A paged array of pets


### PR DESCRIPTION
I noticed a bug when validating requests that have headers.

The `validate_query_parameters!` method was validating against **all** parameters, including headers, and raising a RequestInvalidError with a misleading message.

Ex. with a header named "X-Foo-Header" the error message read:
`"Query parameter invalid: is missing required properties: X-Foo-Header"`

This was confusing since the header is not a query parameter.

The solution I found is to add a `query_parameters_schema` method on the Operation class that filters out request headers. 
That way, `validate_query_parameters!` is in fact only checking query parameters and will not fail when headers are present.

I kept the original method `parameters_schema` intact even though it's not being used, because I thought it could be useful down the road for implementing header validation. But I'm happy to remove it if you think that's cleaner @ahx.

Thanks for this gem, my team has been using it and we find it quite helpful!