### PR TITLE
Don't symbolize request body or parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Breaking change: Request body and parameters now use string keys instead of symbols!
+
 ## 0.21.0
 
 - Fix: Query parameter validation does not fail if header parameters are defined (Thanks to [JF Lalonde](https://github.com/JF-Lalonde))

--- a/benchmarks/apps/openapi_first.ru
+++ b/benchmarks/apps/openapi_first.ru
@@ -5,7 +5,7 @@ require 'openapi_first'
 
 namespace = Module.new do
   def self.find_thing(params, _res)
-    { hello: 'world', id: params.fetch(:id) }
+    { hello: 'world', id: params.fetch('id') }
   end
 
   def self.find_things(_params, _res)

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -57,8 +57,6 @@ module OpenapiFirst
 
       errors = schema.validate(body)
       throw_error(400, serialize_request_body_errors(errors)) if errors.any?
-      return Utils.deep_symbolize(body) if body.is_a?(Hash)
-
       body
     end
 
@@ -112,17 +110,18 @@ module OpenapiFirst
       params = Utils.deep_stringify(params)
       errors = schema.validate(params)
       throw_error(400, serialize_query_parameter_errors(errors)) if errors.any?
-      Utils.deep_symbolize(params)
+      params
     end
 
     def filtered_params(json_schema, params)
       json_schema['properties']
         .each_with_object({}) do |key_value, result|
-          parameter_name = key_value[0].to_sym
+          parameter_name = key_value[0]
+          parameter_name_symbol = parameter_name.to_sym
           schema = key_value[1]
-          next unless params.key?(parameter_name)
+          next unless params.key?(parameter_name_symbol)
 
-          value = params[parameter_name]
+          value = params[parameter_name_symbol]
           result[parameter_name] = parse_parameter(value, schema)
         end
     end

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -107,7 +107,6 @@ module OpenapiFirst
       return unless schema
 
       params = filtered_params(schema.raw_schema, params)
-      params = Utils.deep_stringify(params)
       errors = schema.validate(params)
       throw_error(400, serialize_query_parameter_errors(errors)) if errors.any?
       params

--- a/lib/openapi_first/utils.rb
+++ b/lib/openapi_first/utils.rb
@@ -18,10 +18,6 @@ module OpenapiFirst
       Hanami::Utils::String.classify(string)
     end
 
-    def self.deep_symbolize(hash)
-      Hanami::Utils::Hash.deep_symbolize(hash)
-    end
-
     def self.deep_stringify(hash)
       Hanami::Utils::Hash.deep_stringify(hash)
     end

--- a/lib/openapi_first/utils.rb
+++ b/lib/openapi_first/utils.rb
@@ -17,9 +17,5 @@ module OpenapiFirst
     def self.classify(string)
       Hanami::Utils::String.classify(string)
     end
-
-    def self.deep_stringify(hash)
-      Hanami::Utils::Hash.deep_stringify(hash)
-    end
   end
 end

--- a/spec/request_validation/request_body_validation_spec.rb
+++ b/spec/request_validation/request_body_validation_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe 'Request body validation' do
 
     let(:request_body) do
       {
-        type: 'pet',
-        attributes: {
-          name: 'Oscar'
+        'type' => 'pet',
+        'attributes' => {
+          'name' => 'Oscar'
         }
       }
     end
@@ -79,10 +79,10 @@ RSpec.describe 'Request body validation' do
       status, _headers, body = app.call(env)
 
       expect(status).to eq(200), body
-      uploaded_file = env[OpenapiFirst::REQUEST_BODY][:file]
-      expect(uploaded_file[:type]).to eq 'text/plain'
-      expect(uploaded_file[:filename]).to eq 'foo.txt'
-      expect(uploaded_file[:tempfile].read).to eq file_content
+      uploaded_file = env[OpenapiFirst::REQUEST_BODY]['file']
+      expect(uploaded_file['type']).to eq 'text/plain'
+      expect(uploaded_file['filename']).to eq 'foo.txt'
+      expect(uploaded_file['tempfile'].read).to eq file_content
     end
 
     it 'supports text/plain content type' do
@@ -95,9 +95,9 @@ RSpec.describe 'Request body validation' do
 
     it 'works with % in request body' do
       request_body = {
-        type: 'pet',
-        attributes: {
-          name: 'Oscar 100%'
+        'type' => 'pet',
+        'attributes' => {
+          'name' => 'Oscar 100%'
         }
       }
       header Rack::CONTENT_TYPE, 'application/json'
@@ -146,7 +146,7 @@ RSpec.describe 'Request body validation' do
     end
 
     it 'returns 400 if request body is not valid' do
-      request_body[:attributes][:name] = 43
+      request_body['attributes']['name'] = 43
       header Rack::CONTENT_TYPE, 'application/json'
       post path, json_dump(request_body)
 
@@ -157,7 +157,7 @@ RSpec.describe 'Request body validation' do
     end
 
     it 'returns 400 if required field is missing' do
-      request_body[:attributes].delete(:name)
+      request_body['attributes'].delete('name')
       header Rack::CONTENT_TYPE, 'application/json'
       post path, json_dump(request_body)
 
@@ -168,7 +168,7 @@ RSpec.describe 'Request body validation' do
     end
 
     it 'returns 400 if value is not defined in enum' do
-      request_body[:type] = 'unknown-type'
+      request_body['type'] = 'unknown-type'
       header Rack::CONTENT_TYPE, 'application/json'
       post path, json_dump(request_body)
 
@@ -180,7 +180,7 @@ RSpec.describe 'Request body validation' do
     end
 
     it 'returns 400 if additional property is not allowed' do
-      request_body[:attributes].update(foo: :bar)
+      request_body['attributes'].update('foo' => :bar)
       header Rack::CONTENT_TYPE, 'application/json'
       post path, json_dump(request_body)
 
@@ -208,7 +208,7 @@ RSpec.describe 'Request body validation' do
         post '/with-default-body-value', json_dump(params)
         expect(last_response.status).to eq(200)
         values = last_request.env[OpenapiFirst::INBOX]
-        expect(values[:has_default]).to eq true
+        expect(values['has_default']).to eq true
       end
 
       it 'still validates the value' do
@@ -224,7 +224,7 @@ RSpec.describe 'Request body validation' do
         post '/with-default-body-value', json_dump(params)
         expect(last_response.status).to eq(200)
         values = last_request.env[OpenapiFirst::INBOX]
-        expect(values[:has_default]).to eq false
+        expect(values['has_default']).to eq false
       end
     end
 
@@ -317,8 +317,8 @@ RSpec.describe 'Request body validation' do
       it 'fails if request includes readOnly field' do
         header Rack::CONTENT_TYPE, 'application/json'
         request_body = {
-          name: 'foo',
-          id: '123'
+          'name' => 'foo',
+          'id' => '123'
         }
         expect do
           post '/test', json_dump(request_body)
@@ -358,7 +358,7 @@ RSpec.describe 'Request body validation' do
       let(:raise_error_option) { true }
 
       it 'raises error if request body is not valid' do
-        request_body[:attributes][:name] = 43
+        request_body['attributes']['name'] = 43
         header Rack::CONTENT_TYPE, 'application/json'
         expect do
           post path, json_dump(request_body)
@@ -366,7 +366,7 @@ RSpec.describe 'Request body validation' do
       end
 
       it 'raises error if required field is missing' do
-        request_body[:attributes].delete(:name)
+        request_body['attributes'].delete('name')
         header Rack::CONTENT_TYPE, 'application/json'
         expect do
           post path, json_dump(request_body)

--- a/spec/responder_spec.rb
+++ b/spec/responder_spec.rb
@@ -220,11 +220,8 @@ RSpec.describe OpenapiFirst::Responder do
       end
 
       it 'has allowed query string parameters' do
-        expected_params = {
-          tags: ['foo']
-        }
         expect(namespace).to receive(:find_pets) do |params, _res|
-          expect(params).to eq expected_params
+          expect(params).to eq('tags' => ['foo'])
         end
 
         get '/pets', 'tags[]' => 'foo', 'foo' => 'bar'
@@ -232,12 +229,12 @@ RSpec.describe OpenapiFirst::Responder do
 
       it 'has path parameters and request body' do
         pet = {
-          type: 'pet',
-          attributes: { name: 'Frido' }
+          'type' => 'pet',
+          'attributes' => { 'name' => 'Frido' }
         }
 
         expected_params = {
-          id: 1
+          'id' => 1
         }.merge(pet)
 
         expect(namespace).to receive(:update_pet) do |params, _res|


### PR DESCRIPTION
This improves performance quite a lot (from  7.000  i/100ms to 8.000  i/100ms)