### PR TITLE
1.0.0.beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
-## Unreleased
-
+## 1.0.0.beta1
 - Removed: `OpenapiFirst::Responder` and `OpenapiFirst::RackResponder`
 - Removed: `OpenapiFirst.app` and `OpenapiFirst.middleware`
+- Removed: `OpenapiFirst::Coverage`
 - Breaking: Parsed query and path parameters are available at `env[OpenapiFirst::PARAMS]`(or `env['openapi.params']`) instead of `OpenapiFirst::PARAMETERS`.
-- Removed: `OpenapiFirst::Coverage`, beause it's out of scope for this gem.
 - Breaking: Request body and parameters now use string keys instead of symbols!
 - Breaking: Query parameters are now parsed exactly like in the API description via the openapi_parameters gem. This means a couple of things:
   - Query parameters now support `explode: true` (default) and `explode: false` for array and object parameters.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (0.21.0)
+    openapi_first (1.0.0.beta1)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.0)
       hanami-utils (~> 2.0.0)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (0.21.0)
+    openapi_first (1.0.0.beta1)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.0)
       hanami-utils (~> 2.0.0)
@@ -95,7 +95,7 @@ GEM
       rack (>= 0.4)
     rack-protection (3.0.5)
       rack
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.0)
     roda (3.66.0)
       rack
     ruby2_keywords (0.0.5)

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '0.21.0'
+  VERSION = '1.0.0.beta1'
 end


### PR DESCRIPTION
Lots of changes. See CHANGELOG.md for details. This is the first beta release. Main changes:
- Parse query parameters and path parameters correctly
- Remove `OpenapiFist.app`, `OpenapiFirst::Responder`, `OpenapiFirst::Coverage`