### PR TITLE
Add response header validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add response header validation to ResponseValidation
 - Make parameters available at `env[OpenapiFirst::PATH_PARAMS]`, `env[OpenapiFirst::QUERY_PARAMS]`, `env[OpenapiFirst::HEADER_PARAMS]`, `env[OpenapiFirst::COOKIE_PARAMS]` in case you need to access them separately.
   Merged path and query parameters are still available at `env[OpenapiFirst::PARAMS]`
 - Add cookie parameter validation to RequestValidation

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'pry'
+  gem 'bundler'
+  gem 'rack-test'
+  gem 'rake'
+  gem 'rspec'
   gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,13 @@ PATH
       json_refs (~> 0.1, >= 0.1.7)
       json_schemer (~> 0.2.16)
       multi_json (~> 1.14)
-      openapi_parameters (~> 0.2)
+      openapi_parameters (~> 0.2.2)
       rack (>= 2.2, < 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    coderay (1.1.3)
     diff-lcs (1.5.0)
     ecma-re-validator (0.4.0)
       regexp_parser (~> 2.2)
@@ -24,78 +23,79 @@ GEM
       rack (~> 2.0)
     hansi (0.2.1)
     json (2.6.3)
-    json_refs (0.1.7)
+    json_refs (0.1.8)
       hana
-    json_schemer (0.2.24)
+    json_schemer (0.2.25)
       ecma-re-validator (~> 0.3)
       hana (~> 1.3)
       regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
       uri_template (~> 0.7)
-    method_source (1.0.0)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     mustermann-contrib (3.0.0)
       hansi (~> 0.2.0)
       mustermann (= 3.0.0)
-    openapi_parameters (0.2.1)
+    openapi_parameters (0.2.2)
       rack (>= 2.2)
       zeitwerk (~> 2.6)
-    parallel (1.22.1)
-    parser (3.2.1.1)
+    parallel (1.23.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    rack (2.2.6.4)
+    rack (2.2.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.0)
     rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.1)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.48.1)
+    rubocop (1.51.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.26.0, < 2.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
+    rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     uri_template (0.7.0)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
-  bundler (~> 2)
+  bundler
   openapi_first!
-  pry
-  rack-test (~> 1)
-  rake (~> 13)
-  rspec (~> 3)
+  rack-test
+  rake
+  rspec
   rubocop
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 [![Join the chat at https://gitter.im/openapi_first/community](https://badges.gitter.im/openapi_first/community.svg)](https://gitter.im/openapi_first/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-OpenapiFirst helps to implement HTTP APIs based on an [OpenAPI](https://www.openapis.org/) API description.
+OpenapiFirst helps to implement HTTP APIs based on an [OpenAPI](https://www.openapis.org/) API description. It supports OpenAPI 3.0 and 3.1.
 
 It provides these Rack middlewares:
 
 - [`OpenapiFirst::RequestValidation`](#request-validation) – Validates the request against the API description and returns 400 if the request is invalid.
 - [`OpenapiFirst::ResponseValidation`](#response-validation) Validates the response and raises an exception if the response body is invalid.
 - [`OpenapiFirst::Router`](#openapifirstrouter) – This internal middleware is added automatically when using request/response validation. It adds the OpenAPI operation for the current request to the Rack env.
+
+Using Request and Response validation together ensures that your implementation follows exactly the API description. This enables you to use the API description as a single source of truth for your API, reason about details and use various tooling.
 
 ## Request Validation
 

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -6,13 +6,13 @@ PATH
       json_refs (~> 0.1, >= 0.1.7)
       json_schemer (~> 0.2.16)
       multi_json (~> 1.14)
-      openapi_parameters (~> 0.2)
+      openapi_parameters (~> 0.2.2)
       rack (>= 2.2, < 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.0.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -42,12 +42,12 @@ GEM
       zeitwerk (~> 2.6)
     ecma-re-validator (0.4.0)
       regexp_parser (~> 2.2)
-    grape (1.7.0)
+    grape (1.7.1)
       activesupport
       builder
       dry-types (>= 1.1)
       mustermann-grape (~> 1.0.0)
-      rack (>= 1.3.0)
+      rack (>= 1.3.0, < 3)
       rack-accept
     hana (1.3.7)
     hanami-api (0.3.0)
@@ -57,15 +57,16 @@ GEM
       mustermann-contrib (~> 3.0)
       rack (~> 2.0)
     hansi (0.2.1)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
-    json_refs (0.1.7)
+    json_refs (0.1.8)
       hana
     json_schema (0.21.0)
-    json_schemer (0.2.24)
+    json_schemer (0.2.25)
       ecma-re-validator (~> 0.3)
       hana (~> 1.3)
       regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
       uri_template (~> 0.7)
     memory_profiler (1.0.1)
     minitest (5.18.0)
@@ -78,22 +79,24 @@ GEM
     mustermann-grape (1.0.2)
       mustermann (>= 1.0.0)
     nio4r (2.5.9)
-    openapi_parameters (0.2.1)
+    openapi_parameters (0.2.2)
       rack (>= 2.2)
       zeitwerk (~> 2.6)
     openapi_parser (1.0.0)
-    puma (6.2.2)
+    puma (6.3.0)
       nio4r (~> 2.0)
-    rack (2.2.6.4)
+    rack (2.2.7)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-protection (3.0.6)
       rack
     regexp_parser (2.8.0)
-    roda (3.67.0)
+    roda (3.68.0)
       rack
     ruby2_keywords (0.0.5)
     seg (1.2.0)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
     sinatra (3.0.6)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
@@ -105,8 +108,11 @@ GEM
     tilt (2.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     uri_template (0.7.0)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   arm64-darwin-21

--- a/lib/openapi_first/errors.rb
+++ b/lib/openapi_first/errors.rb
@@ -22,6 +22,8 @@ module OpenapiFirst
 
   class ResponseBodyInvalidError < ResponseInvalid; end
 
+  class ResponseHeaderInvalidError < ResponseInvalid; end
+
   class BodyParsingError < Error; end
 
   class RequestInvalidError < Error

--- a/lib/openapi_first/response_validation.rb
+++ b/lib/openapi_first/response_validation.rb
@@ -28,6 +28,7 @@ module OpenapiFirst
       content_type = headers[Rack::CONTENT_TYPE]
       response_schema = operation.response_body_schema(status, content_type)
       validate_response_body(response_schema, body) if response_schema
+      validate_response_headers(operation, status, headers)
     end
 
     private
@@ -42,15 +43,48 @@ module OpenapiFirst
       data = full_body.empty? ? {} : load_json(full_body)
       errors = schema.validate(data)
       errors = errors.to_a.map! do |error|
-        format_error(error)
+        format_response_error(error)
       end
       raise ResponseBodyInvalidError, errors.join(', ') if errors.any?
     end
 
-    def format_error(error)
+    def validate_response_headers(operation, status, response_headers)
+      response_header_definitions = operation.response_for(status)&.dig('headers')
+      return unless response_header_definitions
+
+      unpacked_headers = unpack_response_headers(response_header_definitions, response_headers)
+      response_header_definitions.each do |name, definition|
+        next if name == 'Content-Type'
+
+        unless response_headers.key?(name)
+          raise ResponseHeaderInvalidError, "Required response header '#{name}' is missing" if definition['required']
+
+          next
+        end
+        next unless definition.key?('schema')
+
+        validation = SchemaValidation.new(definition['schema'])
+        value = unpacked_headers[name]
+        errors = validation.validate(value).to_a.map! { |error| format_header_error(error, name) }
+        raise ResponseHeaderInvalidError, errors.join(', ') if errors.any?
+      end
+    end
+
+    def unpack_response_headers(response_header_definitions, response_headers)
+      headers_as_parameters = response_header_definitions.map do |name, definition|
+        definition.merge('name' => name)
+      end
+      OpenapiParameters::Header.new(headers_as_parameters).unpack(response_headers)
+    end
+
+    def format_response_error(error)
       return "Write-only field appears in response: #{error['data_pointer']}" if error['type'] == 'writeOnly'
 
       JSONSchemer::Errors.pretty(error)
+    end
+
+    def format_header_error(error, name)
+      "Response header '#{name}' #{ErrorFormat.error_details(error)[:title]}"
     end
 
     def load_json(string)

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json_refs', '~> 0.1', '>= 0.1.7'
   spec.add_runtime_dependency 'json_schemer', '~> 0.2.16'
   spec.add_runtime_dependency 'multi_json', '~> 1.14'
-  spec.add_runtime_dependency 'openapi_parameters', '~> 0.2'
+  spec.add_runtime_dependency 'openapi_parameters', '~> 0.2.2'
   spec.add_runtime_dependency 'rack', '>= 2.2', '< 4.0'
 
   spec.add_development_dependency 'bundler', '~> 2'

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['andreas.haller@posteo.de']
   spec.licenses      = ['MIT']
 
-  spec.summary       = 'Implement REST APIs based on OpenApi.'
+  spec.summary       = 'Implement REST APIs based on OpenApi 3.x'
   spec.homepage      = 'https://github.com/ahx/openapi_first'
 
   if spec.respond_to?(:metadata)
@@ -40,11 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'multi_json', '~> 1.14'
   spec.add_runtime_dependency 'openapi_parameters', '~> 0.2.2'
   spec.add_runtime_dependency 'rack', '>= 2.2', '< 4.0'
-
-  spec.add_development_dependency 'bundler', '~> 2'
-  spec.add_development_dependency 'rack-test', '~> 1'
-  spec.add_development_dependency 'rake', '~> 13'
-  spec.add_development_dependency 'rspec', '~> 3'
   spec.metadata = {
     'rubygems_mfa_required' => 'true'
   }

--- a/spec/data/no-response-content.yaml
+++ b/spec/data/no-response-content.yaml
@@ -1,0 +1,13 @@
+openapi: "3.1.0"
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: A response without content defined
+  /empty-content:
+    get:
+      responses:
+        '200':
+          description: A response without content defined
+          content:

--- a/spec/data/response-header.yaml
+++ b/spec/data/response-header.yaml
@@ -1,0 +1,31 @@
+openapi: 3.1.0
+info:
+paths:
+  '/echo':
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Ok
+          headers:
+            OptionalWithoutSchema:
+              description: 'optonal'
+            'Content-Type':
+              required: true
+              schema:
+                type: string
+                const: 'this should be ignored'
+            Location:
+              required: true
+              schema:
+                type: string
+                format: uri-reference
+            X-Id:
+              schema:
+                type: integer
+

--- a/spec/response_validator_spec.rb
+++ b/spec/response_validator_spec.rb
@@ -40,18 +40,20 @@ RSpec.describe OpenapiFirst::ResponseValidator do
       subject.validate(request, response)
     end
 
-    it 'returns no errors if OAS file has no content' do
-      expect_any_instance_of(OpenapiFirst::Operation).to receive(:response_for) { {} }
-      response = Rack::MockResponse.new(200, headers, 'body')
-      subject.validate(request, response)
-    end
+    describe 'when operation response has has no content defined' do
+      let(:spec) { './spec/data/no-response-content.yaml' }
 
-    it 'returns no errors if OAS file has no response_for schema specified' do
-      empty_content = { 'application/json' => {} }
-      expect_any_instance_of(OpenapiFirst::Operation)
-        .to receive(:response_for) { { 'content' => empty_content } }
-      response = Rack::MockResponse.new(200, headers, 'body')
-      subject.validate(request, response)
+      it 'returns no errors' do
+        request = Rack::Request.new(Rack::MockRequest.env_for('/'))
+        response = Rack::MockResponse.new(200, headers, 'body')
+        subject.validate(request, response)
+      end
+
+      it 'returns no errors when content type is empty' do
+        request = Rack::Request.new(Rack::MockRequest.env_for('/empty-content'))
+        response = Rack::MockResponse.new(200, headers, 'body')
+        subject.validate(request, response)
+      end
     end
   end
 


### PR DESCRIPTION
Raise ResponseHeaderInvalid if response header is missing or invalid

Closes https://github.com/ahx/openapi_first/issues/182

TODO: Unpack response headers, similar to request headers. See https://spec.openapis.org/oas/latest.html#headerObject