### PR TITLE
Fix metadata of gemspec

### DIFF
--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   if spec.respond_to?(:metadata)
     spec.metadata['https://github.com/ahx/openapi_first'] = spec.homepage
     spec.metadata['source_code_uri'] = 'https://github.com/ahx/openapi_first'
-    spec.metadata['changelog_uri'] = 'https://github.com/ahx/openapi_first/blob/master/CHANGELOG.md'
+    spec.metadata['changelog_uri'] = 'https://github.com/ahx/openapi_first/blob/main/CHANGELOG.md'
     spec.metadata['rubygems_mfa_required'] = 'true'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
     spec.metadata['https://github.com/ahx/openapi_first'] = spec.homepage
     spec.metadata['source_code_uri'] = 'https://github.com/ahx/openapi_first'
     spec.metadata['changelog_uri'] = 'https://github.com/ahx/openapi_first/blob/master/CHANGELOG.md'
+    spec.metadata['rubygems_mfa_required'] = 'true'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
           'public gem pushes.'
@@ -43,7 +44,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mustermann-contrib', '~> 3.0.0'
   spec.add_runtime_dependency 'openapi_parameters', '>= 0.3.2', '< 2.0'
   spec.add_runtime_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.metadata = {
-    'rubygems_mfa_required' => 'true'
-  }
 end


### PR DESCRIPTION
Currently, gem's metadata is only enabled for`rubygems_mfa_required`.
This is because other metadata was overridden when setting `rubygems_mfa_required`. 

This fixed the issue. Also, fixed the `changelog_uri` to the correct branch name.