### PR TITLE
Better JSON parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - Added methods `known?`, `status_type`, `body`, `headers` to `RuntimeResponse` to inspect the parsed response
+- Add `OpenapiFirst::ParseError` which is raised by low-level interfaces like `request.body` if the body could not be parsed.
 
 ## 1.0.0
 

--- a/lib/openapi_first/body_parser.rb
+++ b/lib/openapi_first/body_parser.rb
@@ -4,7 +4,11 @@ require 'multi_json'
 
 module OpenapiFirst
   class BodyParser
-    class ParsingError < StandardError; end
+    def self.const_missing(const_name)
+      super unless const_name == :ParsingError
+      warn 'DEPRECATION WARNING: OpenapiFirst::BodyParser::ParsingError is deprecated. Use OpenapiFirst::ParseError instead.' # rubocop:disable Layout/LineLength
+      OpenapiFirst::ParseError
+    end
 
     def parse(request, content_type)
       body = read_body(request)
@@ -15,7 +19,7 @@ module OpenapiFirst
 
       body
     rescue MultiJson::ParseError
-      raise ParsingError, 'Failed to parse body as JSON'
+      raise ParseError, 'Failed to parse body as JSON'
     end
 
     private

--- a/lib/openapi_first/errors.rb
+++ b/lib/openapi_first/errors.rb
@@ -2,6 +2,7 @@
 
 module OpenapiFirst
   class Error < StandardError; end
+  class ParseError < Error; end
   class NotFoundError < Error; end
   class RequestInvalidError < Error; end
   class ResponseNotFoundError < Error; end

--- a/lib/openapi_first/request_validation/validator.rb
+++ b/lib/openapi_first/request_validation/validator.rb
@@ -73,7 +73,7 @@ module OpenapiFirst
         return unless operation.request_body
 
         RequestBodyValidator.new(operation).validate!(request.body, request.content_type)
-      rescue BodyParser::ParsingError => e
+      rescue ParseError => e
         Failure.fail!(:invalid_body, message: e.message)
       end
     end

--- a/lib/openapi_first/response_validation/validator.rb
+++ b/lib/openapi_first/response_validation/validator.rb
@@ -15,7 +15,7 @@ module OpenapiFirst
         catch Failure::FAILURE do
           validate_defined(runtime_response)
           response_definition = runtime_response.response_definition
-          validate_response_body(response_definition.content_schema, runtime_response.body)
+          validate_response_body(response_definition.content_schema, runtime_response)
           validate_response_headers(response_definition.headers, runtime_response.headers)
           nil
         end
@@ -43,8 +43,14 @@ module OpenapiFirst
         Failure.fail!(:invalid_response_header, message:)
       end
 
-      def validate_response_body(schema, parsed_body)
+      def validate_response_body(schema, runtime_response)
         return unless schema
+
+        begin
+          parsed_body = runtime_response.body
+        rescue ParseError => e
+          Failure.fail!(:invalid_response_body, message: e.message)
+        end
 
         validation = schema.validate(parsed_body)
         Failure.fail!(:invalid_response_body, errors: validation.errors) if validation.error?

--- a/lib/openapi_first/runtime_response.rb
+++ b/lib/openapi_first/runtime_response.rb
@@ -29,10 +29,7 @@ module OpenapiFirst
     end
 
     def body
-      @body ||= begin
-        read_body = @rack_response.body.join
-        content_type =~ /json/i ? load_json(read_body) : read_body
-      end
+      @body ||= content_type =~ /json/i ? load_json(original_body) : original_body
     end
 
     def headers
@@ -54,10 +51,14 @@ module OpenapiFirst
 
     private
 
+    def original_body
+      @rack_response.body.join
+    end
+
     def load_json(string)
       MultiJson.load(string)
     rescue MultiJson::ParseError
-      string
+      raise ParseError, 'Failed to parse response body as JSON'
     end
 
     def unpack_response_headers

--- a/spec/middlewares/request_validation_spec.rb
+++ b/spec/middlewares/request_validation_spec.rb
@@ -30,9 +30,28 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
     end
   end
 
-  context 'when request is invalid' do
+  context 'when parameter is invalid' do
     it 'returns 400' do
       get '/pets?limit=three'
+
+      expect(last_response.status).to eq 400
+    end
+  end
+
+  context 'when request body is invalid JSON' do
+    let(:app) do
+      Rack::Builder.app do
+        use(OpenapiFirst::Middlewares::RequestValidation,
+            spec: File.expand_path('../data/petstore-expanded.yaml', __dir__))
+        run lambda { |_env|
+          Rack::Response.new('hello', 200).finish
+        }
+      end
+    end
+
+    it 'returns 400' do
+      header 'Content-Type', 'application/json'
+      post '/pets', 'not json'
 
       expect(last_response.status).to eq 400
     end

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'rack'
+require 'rack/test'
+require 'openapi_first'
+
+RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
+  include Rack::Test::Methods
+
+  let(:app) do
+    Rack::Builder.app do
+      use(OpenapiFirst::Middlewares::ResponseValidation, spec: File.expand_path('../data/petstore.yaml', __dir__))
+      run lambda { |_env|
+        Rack::Response.new('[]', 200, { 'Content-Type' => 'application/json' }).finish
+      }
+    end
+  end
+
+  context 'when response is valid' do
+    it 'returns 200' do
+      get '/pets'
+
+      expect(last_response.status).to eq 200
+    end
+
+    it 'adds request to env ' do
+      get '/pets'
+      expect(last_request.env[OpenapiFirst::REQUEST]).to be_a OpenapiFirst::RuntimeRequest
+    end
+  end
+
+  context 'when response is invalid' do
+    let(:app) do
+      Rack::Builder.new.tap do |builder|
+        builder.use(described_class, spec: File.expand_path('../data/petstore.yaml', __dir__))
+        builder.run lambda { |_env|
+          Rack::Response.new('{"foo": "bar"}', 200, { 'Content-Type' => 'application/json' }).finish
+        }
+      end.to_app
+    end
+
+    it 'raises an error' do
+      expect do
+        get '/pets'
+      end.to raise_error OpenapiFirst::ResponseInvalidError, 'Response body is invalid: value at root is not an array'
+    end
+  end
+
+  context 'when response is not valid JSON' do
+    let(:app) do
+      Rack::Builder.new.tap do |builder|
+        builder.use(described_class, spec: File.expand_path('../data/petstore.yaml', __dir__))
+        builder.run lambda { |_env|
+          Rack::Response.new('{boofar}', 200, { 'Content-Type' => 'application/json' }).finish
+        }
+      end.to_app
+    end
+
+    it 'raises an error' do
+      expect do
+        get '/pets'
+      end.to raise_error OpenapiFirst::ResponseInvalidError,
+                         'Response body is invalid: value at root is not an array'
+    end
+  end
+
+  context 'when path is not found' do
+    it 'ignores the request' do
+      get '/unknown'
+      expect(last_response.status).to eq 200
+    end
+  end
+end

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
       expect do
         get '/pets'
       end.to raise_error OpenapiFirst::ResponseInvalidError,
-                         'Response body is invalid: value at root is not an array'
+                         'Response body is invalid: Failed to parse response body as JSON'
     end
   end
 

--- a/spec/runtime_request_spec.rb
+++ b/spec/runtime_request_spec.rb
@@ -268,6 +268,18 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
       expect(subject.body).to eq('foo' => 'bar')
     end
 
+    context 'with invalid JSON' do
+      let(:rack_request) do
+        env = Rack::MockRequest.env_for('/pets', method: 'POST', input: '{foobar}')
+        env['CONTENT_TYPE'] = 'application/json'
+        Rack::Request.new(env)
+      end
+
+      it 'raises a ParseError' do
+        expect { subject.body }.to raise_error(OpenapiFirst::ParseError, 'Failed to parse body as JSON')
+      end
+    end
+
     it 'is aliased with parsed_body' do
       expect(subject.parsed_body).to eq('foo' => 'bar')
     end

--- a/spec/runtime_response_spec.rb
+++ b/spec/runtime_response_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe OpenapiFirst::RuntimeResponse do
         expect(response.body).to eq(JSON.dump({ foo: :bar }))
       end
     end
+
+    context 'with invalid JSON' do
+      let(:rack_response) do
+        Rack::Response.new('{foobar}', 200, { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises a ParseError' do
+        expect do
+          response.body
+        end.to raise_error OpenapiFirst::ParseError, 'Failed to parse response body as JSON'
+      end
+    end
   end
 
   describe '#name' do


### PR DESCRIPTION
This  adds `OpenapiFirst::ParseError` which is raised by low-level interfaces like `request.body` if the body could not be parsed.
This changes the error message to something less technical, which is irrelevant most of the time anyways. Also the new error message gives no clue about what JSON parser is used, which is also good.

Before: "unexpected token at {foobar}"
After: "Failed to parse body as JSON"