### PR TITLE
Expose operation on the runtime_request.

### DIFF
--- a/lib/openapi_first/runtime_request.rb
+++ b/lib/openapi_first/runtime_request.rb
@@ -22,7 +22,7 @@ module OpenapiFirst
     def_delegators :@operation, :operation_id, :request_method
     def_delegator :@path_item, :path, :path_definition
 
-    attr_reader :path_item
+    attr_reader :path_item, :operation
 
     def known?
       known_path? && known_request_method?
@@ -90,6 +90,6 @@ module OpenapiFirst
 
     private
 
-    attr_reader :request, :operation
+    attr_reader :request
   end
 end

--- a/spec/runtime_request_spec.rb
+++ b/spec/runtime_request_spec.rb
@@ -308,4 +308,10 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
       expect(subject.request_method).to eq('get')
     end
   end
+
+  describe '#operation' do
+    it 'returns the request operation' do
+      expect(request.operation.path).to eq('/pets/{petId}')
+    end
+  end
 end


### PR DESCRIPTION
I'd like to be able to programmatically access the OAS definition details. Exposing the `operation` would make it possible by doing: `request(env).operation[key]`

What do you think about that? :)