### PR TITLE
Support special characters in path params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added support for unescaped special characters in the path params (https://github.com/ahx/openapi_first/pull/217)
 - Added `operation` to `RuntimeRequest` by [@MrBananaLord](https://github.com/ahx/openapi_first/pull/216)
 
 ## 1.1.1

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'mustermann/template'
+require 'mustermann'
 require_relative 'definition/path_item'
 require_relative 'runtime_request'
 
@@ -60,7 +60,7 @@ module OpenapiFirst
 
     def search_for_path_item(request_path)
       paths.find do |path, path_item_object|
-        template = Mustermann::Template.new(path)
+        template = Mustermann.new(path)
         path_params = template.params(request_path)
         next unless path_params
         next unless path_params.size == template.names.size

--- a/spec/data/path-parameter-validation.yaml
+++ b/spec/data/path-parameter-validation.yaml
@@ -17,3 +17,17 @@ paths:
       responses:
         '200':
           description: successful
+  /users/{userName}:
+    parameters: 
+      - name: userName
+        in: path
+        required: true
+        schema:
+          type: string
+    get: 
+      summary: Find users by user name
+      operationId: findUserByUserName
+      responses:
+        '200':
+          description: successful
+      

--- a/spec/request_validation/path_parameter_validation_spec.rb
+++ b/spec/request_validation/path_parameter_validation_spec.rb
@@ -30,14 +30,26 @@ RSpec.describe 'Path Parameter validation' do
       expect(last_response.status).to eq 400
     end
 
-    it 'adds the converted path parameter to env ' do
+    it 'adds the converted path parameter to env' do
       get '/pets/42'
       expect(last_request.env[OpenapiFirst::REQUEST].params['petId']).to eq 42
     end
 
-    it 'succeeds if path parameter are valid' do
-      get '/pets/42'
-      expect(last_response.status).to be 200
+    context 'with valid parameters' do
+      it 'succeeds for valid integer' do
+        get '/pets/42'
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'succeeds for valid string' do
+        get '/users/joe'
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'succeds for string with special characters' do
+        get '/users/joe!doe'
+        expect(last_response.status).to eq(200)
+      end
     end
 
     it 'returns 404 if path parameter is empty' do


### PR DESCRIPTION
Hi :)

I ran into an issue where my request `/users/{name}` (where `name` is a string) ended up raising `OpenapiFirst::NotFound` error when the `name` had special characters in it. It seems to be caused by the `Mustermann::Template.new(...)`. When replaced with `Mustermann.new(...)` the issue is resolved.

I am not sure why are you using the `Mustermann::Template.new(...)` there 🤔 when checking the readme of Mustermann it seems that the intended use is via `Mustermann.new(...)` :)

I added a spec to make it more visible what's happening. What do you think about this?