### PR TITLE
Add  validate_request API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added new API: `Definition#validate_request`, `Definition#validate_response`, `RuntimeRequest#validate_response` (see readme) [#222](https://github.com/ahx/openapi_first/pull/222)
+
 ## 1.2.0
 
 - Added `OpenapiFirst.parse(hash)` to load ("parse") a resolved/de-referenced Hash

--- a/README.md
+++ b/README.md
@@ -39,19 +39,9 @@ rack_request = Rack::Request.new(env)
 # Find and validate request
 request = definition.validate_request(rack_request)
 request.valid? # => true / false
-request.validation_failure # => Failure object if request is invalid
-request.validation_failure&.raise! # Raises NotFoundError or RequestInvalidError
-
-# or find, validate and raise
-request = definition.validate_request(rack_request, raise_error: true)
-
-# or find, then validate
-request = definition.request(rack_request)
-request.validate
-
-# or find, then validate and raise
-request = definition.request(rack_request)
-request.validate!
+request.error # => Failure object if request is invalid
+# Or raise an exception if validation fails:
+request = definition.validate_request(rack_request, raise_error: true) # Raises OpenapiFirst::RequestInvalidError or OpenapiFirst::NotFoundError if request is invalid
 
 # Access parsed parameters
 request.body # alias: parsed_body
@@ -60,13 +50,11 @@ request.query # alias: query_parameters
 request.params # Merged path and query parameters
 request.headers
 request.cookies
-
 # Inspect the request
 request.known? # Is the request defined in the API description?
 request.content_type
 request.request_method # => "get"
 request.path # => "/pets/42"
-request.path_definition # => "/pets/{pet_id}"
 ```
 
 ### Validate response
@@ -75,23 +63,20 @@ request.path_definition # => "/pets/{pet_id}"
 # Find and validate the response
 rack_response = Rack::Response[*app.call(env)]
 response = definition.validate_response(rack_request, rack_response)
-# or if you want to raise an error when validation fails use:
-definition.validate_response(rack_request,rack_response, raise_error: true) # Raises OpenapiFirst::ResponseInvalidError or OpenapiFirst::ResponseNotFoundError
-# You can also call a method on the request object
+# Raise an exception if validation fails:
+response = definition.validate_response(rack_request,rack_response, raise_error: true) # Raises OpenapiFirst::ResponseInvalidError or OpenapiFirst::ResponseNotFoundError
+# Or you can also call a method on the request object mentioned above
 request.validate_response(rack_response)
 
+# Access parsed response
+response.body
+request.headers
 # Inspect the response
 response.known? # Is the response defined in the API description?
-request.valid? # => true / false
-request.validation_failure # => Failure object if response is invalid
+response.valid? # => true / false
+response.error # => Failure object if response is invalid
 response.status # => 200
 response.content_type
-response.body
-request.headers # parsed response headers
-
-# Validate response
-response.validate # Returns OpenapiFirst::Failure if validation fails
-response.validate! # Raises OpenapiFirst::ResponseInvalidError or OpenapiFirst::ResponseNotFoundError if validation fails
 ```
 
 OpenapiFirst uses [`multi_json`](https://rubygems.org/gems/multi_json).

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ OpenapiFirst helps to implement HTTP APIs based on an [OpenAPI](https://www.open
 
 <!-- TOC -->
 
-- [Manual use](#manual-use)
-  - [Validate request](#validate-request)
-  - [Validate response](#validate-response)
 - [Rack Middlewares](#rack-middlewares)
   - [Request validation](#request-validation)
   - [Response validation](#response-validation)
+- [Manual use](#manual-use)
+  - [Validate request](#validate-request)
+  - [Validate response](#validate-response)
 - [Configuration](#configuration)
 - [Framework integration](#framework-integration)
 - [Alternatives](#alternatives)
@@ -20,64 +20,6 @@ OpenapiFirst helps to implement HTTP APIs based on an [OpenAPI](https://www.open
   - [Contributing](#contributing)
 
 <!-- /TOC -->
-
-## Manual use
-
-Load the API description:
-
-```ruby
-require 'openapi_first'
-
-definition = OpenapiFirst.load('openapi.yaml')
-```
-
-### Validate request
-
-```ruby
-# Find and validate request
-rack_request = Rack::Request.new(env)
-request = definition.validate_request(rack_request)
-# Or raise an exception if validation fails:
-request = definition.validate_request(rack_request, raise_error: true) # Raises OpenapiFirst::RequestInvalidError or OpenapiFirst::NotFoundError if request is invalid
-
-# Inspect the request and access parsed parameters
-request.known? # Is the request defined in the API description?
-request.valid? # => true / false
-request.error # => Failure object if request is invalid
-request.body # alias: parsed_body
-request.path_parameters # => { "pet_id" => 42 }
-request.query # alias: query_parameters
-request.params # Merged path and query parameters
-request.headers
-request.cookies
-request.content_type
-request.request_method # => "get"
-request.path # => "/pets/42"
-```
-
-### Validate response
-
-```ruby
-# Find and validate the response
-rack_response = Rack::Response[*app.call(env)]
-response = definition.validate_response(rack_request, rack_response)
-
-# Raise an exception if validation fails:
-response = definition.validate_response(rack_request,rack_response, raise_error: true) # Raises OpenapiFirst::ResponseInvalidError or OpenapiFirst::ResponseNotFoundError
-# Or you can also call a method on the request object mentioned above
-request.validate_response(rack_response)
-
-# Inspect the response and access parsed parameters and
-response.known? # Is the response defined in the API description?
-response.valid? # => true / false
-response.error # => Failure object if response is invalid
-response.body
-request.headers
-response.status # => 200
-response.content_type
-```
-
-OpenapiFirst uses [`multi_json`](https://rubygems.org/gems/multi_json).
 
 ## Rack Middlewares
 
@@ -193,6 +135,64 @@ use OpenapiFirst::Middlewares::ResponseValidation, spec: 'openapi.yaml' if ENV['
 | Name    | Possible values | Description                                                      |
 | :------ | --------------- | ---------------------------------------------------------------- |
 | `spec:` |                 | The path to the spec file or spec loaded via `OpenapiFirst.load` |
+
+## Manual use
+
+Load the API description:
+
+```ruby
+require 'openapi_first'
+
+definition = OpenapiFirst.load('openapi.yaml')
+```
+
+### Validate request
+
+```ruby
+# Find and validate request
+rack_request = Rack::Request.new(env)
+request = definition.validate_request(rack_request)
+# Or raise an exception if validation fails:
+request = definition.validate_request(rack_request, raise_error: true) # Raises OpenapiFirst::RequestInvalidError or OpenapiFirst::NotFoundError if request is invalid
+
+# Inspect the request and access parsed parameters
+request.known? # Is the request defined in the API description?
+request.valid? # => true / false
+request.error # => Failure object if request is invalid
+request.body # alias: parsed_body
+request.path_parameters # => { "pet_id" => 42 }
+request.query # alias: query_parameters
+request.params # Merged path and query parameters
+request.headers
+request.cookies
+request.content_type
+request.request_method # => "get"
+request.path # => "/pets/42"
+```
+
+### Validate response
+
+```ruby
+# Find and validate the response
+rack_response = Rack::Response[*app.call(env)]
+response = definition.validate_response(rack_request, rack_response)
+
+# Raise an exception if validation fails:
+response = definition.validate_response(rack_request,rack_response, raise_error: true) # Raises OpenapiFirst::ResponseInvalidError or OpenapiFirst::ResponseNotFoundError
+# Or you can also call a method on the request object mentioned above
+request.validate_response(rack_response)
+
+# Inspect the response and access parsed parameters and
+response.known? # Is the response defined in the API description?
+response.valid? # => true / false
+response.error # => Failure object if response is invalid
+response.body
+request.headers
+response.status # => 200
+response.content_type
+```
+
+OpenapiFirst uses [`multi_json`](https://rubygems.org/gems/multi_json).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -34,24 +34,22 @@ definition = OpenapiFirst.load('openapi.yaml')
 ### Validate request
 
 ```ruby
-rack_request = Rack::Request.new(env)
-
 # Find and validate request
+rack_request = Rack::Request.new(env)
 request = definition.validate_request(rack_request)
-request.valid? # => true / false
-request.error # => Failure object if request is invalid
 # Or raise an exception if validation fails:
 request = definition.validate_request(rack_request, raise_error: true) # Raises OpenapiFirst::RequestInvalidError or OpenapiFirst::NotFoundError if request is invalid
 
-# Access parsed parameters
+# Inspect the request and access parsed parameters
+request.known? # Is the request defined in the API description?
+request.valid? # => true / false
+request.error # => Failure object if request is invalid
 request.body # alias: parsed_body
 request.path_parameters # => { "pet_id" => 42 }
 request.query # alias: query_parameters
 request.params # Merged path and query parameters
 request.headers
 request.cookies
-# Inspect the request
-request.known? # Is the request defined in the API description?
 request.content_type
 request.request_method # => "get"
 request.path # => "/pets/42"
@@ -63,18 +61,18 @@ request.path # => "/pets/42"
 # Find and validate the response
 rack_response = Rack::Response[*app.call(env)]
 response = definition.validate_response(rack_request, rack_response)
+
 # Raise an exception if validation fails:
 response = definition.validate_response(rack_request,rack_response, raise_error: true) # Raises OpenapiFirst::ResponseInvalidError or OpenapiFirst::ResponseNotFoundError
 # Or you can also call a method on the request object mentioned above
 request.validate_response(rack_response)
 
-# Access parsed response
-response.body
-request.headers
-# Inspect the response
+# Inspect the response and access parsed parameters and
 response.known? # Is the response defined in the API description?
 response.valid? # => true / false
 response.error # => Failure object if response is invalid
+response.body
+request.headers
 response.status # => 200
 response.content_type
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ OpenapiFirst helps to implement HTTP APIs based on an [OpenAPI](https://www.open
   - [Response validation](#response-validation)
 - [Configuration](#configuration)
 - [Framework integration](#framework-integration)
+- [Alternatives](#alternatives)
 - [Development](#development)
   - [Benchmarks](#benchmarks)
   - [Contributing](#contributing)
@@ -213,6 +214,11 @@ config.middleware.use OpenapiFirst::Middlewares::ResponseValidation,
 
 That way you don't have to call specific test assertions to make sure your API matches the OpenAPI document.
 There is no need to run response validation on production if your test coverage is decent.
+
+## Alternatives
+
+This gem was inspired by [committe](https://github.com/interagent/committee) (Ruby) and [Connexion](https://github.com/spec-first/connexion) (Python).
+Here is a [feature comparison between openapi_first and committee](https://gist.github.com/ahx/1538c31f0652f459861713b5259e366a).
 
 ## Development
 

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -19,7 +19,7 @@ module OpenapiFirst
 
     def validate_request(rack_request, raise_error: false)
       validated = request(rack_request).tap(&:validate)
-      validated.validation_failure&.raise! if raise_error
+      validated.error&.raise! if raise_error
       validated
     end
 

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -3,6 +3,8 @@
 require 'mustermann'
 require_relative 'definition/path_item'
 require_relative 'runtime_request'
+require_relative 'request_validation/validator'
+require_relative 'response_validation/validator'
 
 module OpenapiFirst
   # Represents an OpenAPI API Description document
@@ -13,6 +15,16 @@ module OpenapiFirst
       @filepath = filepath
       @paths = resolved['paths']
       @openapi_version = detect_version(resolved)
+    end
+
+    def validate_request(rack_request, raise_error: false)
+      validated = request(rack_request).tap(&:validate)
+      validated.validation_failure&.raise! if raise_error
+      validated
+    end
+
+    def validate_response(rack_request, rack_response, raise_error: false)
+      request(rack_request).validate_response(rack_response, raise_error:)
     end
 
     def request(rack_request)

--- a/lib/openapi_first/error_response.rb
+++ b/lib/openapi_first/error_response.rb
@@ -29,7 +29,7 @@ module OpenapiFirst
 
     # The response status
     def status
-      STATUS[failure.error_type] || 400
+      STATUS[failure.type] || 400
     end
 
     # Render this error response

--- a/lib/openapi_first/failure.rb
+++ b/lib/openapi_first/failure.rb
@@ -44,6 +44,7 @@ module OpenapiFirst
     end
 
     attr_reader :error_type, :message, :errors
+    alias type error_type
 
     # Raise an exception that fits the failure.
     def raise!

--- a/lib/openapi_first/middlewares/request_validation.rb
+++ b/lib/openapi_first/middlewares/request_validation.rb
@@ -26,11 +26,8 @@ module OpenapiFirst
         request = find_request(env)
         return @app.call(env) unless request
 
-        failure = if @raise
-                    request.validate!
-                  else
-                    request.validate
-                  end
+        failure = request.validate
+        failure.raise! if failure && @raise
         return @error_response_class.new(failure:).render if failure
 
         @app.call(env)

--- a/lib/openapi_first/middlewares/response_validation.rb
+++ b/lib/openapi_first/middlewares/response_validation.rb
@@ -20,11 +20,8 @@ module OpenapiFirst
       def call(env)
         request = find_request(env)
         status, headers, body = @app.call(env)
-
         body = body.to_ary if body.respond_to?(:to_ary)
-
         request.validate_response(Rack::Response[status, headers, body], raise_error: true)
-
         [status, headers, body]
       end
 

--- a/lib/openapi_first/middlewares/response_validation.rb
+++ b/lib/openapi_first/middlewares/response_validation.rb
@@ -23,7 +23,7 @@ module OpenapiFirst
 
         body = body.to_ary if body.respond_to?(:to_ary)
 
-        request.response(Rack::Response[status, headers, body]).validate!
+        request.validate_response(Rack::Response[status, headers, body], raise_error: true)
 
         [status, headers, body]
       end

--- a/lib/openapi_first/plugins/default/error_response.rb
+++ b/lib/openapi_first/plugins/default/error_response.rb
@@ -29,10 +29,10 @@ module OpenapiFirst
           MultiJson.dump(result)
         end
 
-        def error_type = failure.error_type
+        def type = failure.type
 
         def title
-          TITLES.fetch(error_type)
+          TITLES.fetch(type)
         end
 
         def content_type
@@ -51,7 +51,7 @@ module OpenapiFirst
         end
 
         def pointer_key
-          case error_type
+          case type
           when :invalid_body
             :pointer
           when :invalid_query, :invalid_path
@@ -64,7 +64,7 @@ module OpenapiFirst
         end
 
         def pointer(data_pointer)
-          return data_pointer if error_type == :invalid_body
+          return data_pointer if type == :invalid_body
 
           data_pointer.delete_prefix('/')
         end

--- a/lib/openapi_first/plugins/jsonapi/error_response.rb
+++ b/lib/openapi_first/plugins/jsonapi/error_response.rb
@@ -36,7 +36,7 @@ module OpenapiFirst
         end
 
         def pointer_key
-          case failure.error_type
+          case failure.type
           when :invalid_body
             :pointer
           when :invalid_query, :invalid_path
@@ -49,7 +49,7 @@ module OpenapiFirst
         end
 
         def pointer(data_pointer)
-          return data_pointer if failure.error_type == :invalid_body
+          return data_pointer if failure.type == :invalid_body
 
           data_pointer.delete_prefix('/')
         end

--- a/lib/openapi_first/runtime_request.rb
+++ b/lib/openapi_first/runtime_request.rb
@@ -16,7 +16,7 @@ module OpenapiFirst
       @path_item = path_item
       @operation = operation
       @original_path_params = path_params
-      @validation_failure = nil
+      @error = nil
       @validated = false
     end
 
@@ -24,11 +24,11 @@ module OpenapiFirst
     def_delegators :@operation, :operation_id, :request_method
     def_delegator :@path_item, :path, :path_definition
 
-    attr_reader :path_item, :operation, :validation_failure
+    attr_reader :path_item, :operation, :error
 
     def valid?
       validate unless @validated
-      validation_failure.nil?
+      error.nil?
     end
 
     def known?
@@ -84,7 +84,7 @@ module OpenapiFirst
 
     def validate
       @validated = true
-      @validation_failure = RequestValidation::Validator.new(operation).validate(self)
+      @error = RequestValidation::Validator.new(operation).validate(self)
     end
 
     def validate!
@@ -94,7 +94,7 @@ module OpenapiFirst
 
     def validate_response(rack_response, raise_error: false)
       validated = response(rack_response).tap(&:validate)
-      validated.validation_failure&.raise! if raise_error
+      validated.error&.raise! if raise_error
       validated
     end
 

--- a/lib/openapi_first/runtime_request.rb
+++ b/lib/openapi_first/runtime_request.rb
@@ -16,13 +16,20 @@ module OpenapiFirst
       @path_item = path_item
       @operation = operation
       @original_path_params = path_params
+      @validation_failure = nil
+      @validated = false
     end
 
     def_delegators :@request, :content_type, :media_type, :path
     def_delegators :@operation, :operation_id, :request_method
     def_delegator :@path_item, :path, :path_definition
 
-    attr_reader :path_item, :operation
+    attr_reader :path_item, :operation, :validation_failure
+
+    def valid?
+      validate unless @validated
+      validation_failure.nil?
+    end
 
     def known?
       known_path? && known_request_method?
@@ -76,12 +83,19 @@ module OpenapiFirst
     alias parsed_body body
 
     def validate
-      RequestValidation::Validator.new(operation).validate(self)
+      @validated = true
+      @validation_failure = RequestValidation::Validator.new(operation).validate(self)
     end
 
     def validate!
       error = validate
       error&.raise!
+    end
+
+    def validate_response(rack_response, raise_error: false)
+      validated = response(rack_response).tap(&:validate)
+      validated.validation_failure&.raise! if raise_error
+      validated
     end
 
     def response(rack_response)

--- a/lib/openapi_first/runtime_response.rb
+++ b/lib/openapi_first/runtime_response.rb
@@ -11,10 +11,18 @@ module OpenapiFirst
     def initialize(operation, rack_response)
       @operation = operation
       @rack_response = rack_response
+      @validation_failure = nil
     end
+
+    attr_reader :validation_failure
 
     def_delegators :@rack_response, :status, :content_type
     def_delegators :@operation, :name
+
+    def valid?
+      validate unless @validated
+      @validation_failure.nil?
+    end
 
     def known?
       !!response_definition
@@ -37,7 +45,8 @@ module OpenapiFirst
     end
 
     def validate
-      ResponseValidation::Validator.new(@operation).validate(self)
+      @validated = true
+      @validation_failure = ResponseValidation::Validator.new(@operation).validate(self)
     end
 
     def validate!

--- a/lib/openapi_first/runtime_response.rb
+++ b/lib/openapi_first/runtime_response.rb
@@ -11,17 +11,17 @@ module OpenapiFirst
     def initialize(operation, rack_response)
       @operation = operation
       @rack_response = rack_response
-      @validation_failure = nil
+      @error = nil
     end
 
-    attr_reader :validation_failure
+    attr_reader :error
 
     def_delegators :@rack_response, :status, :content_type
     def_delegators :@operation, :name
 
     def valid?
       validate unless @validated
-      @validation_failure.nil?
+      @error.nil?
     end
 
     def known?
@@ -46,7 +46,7 @@ module OpenapiFirst
 
     def validate
       @validated = true
-      @validation_failure = ResponseValidation::Validator.new(@operation).validate(self)
+      @error = ResponseValidation::Validator.new(@operation).validate(self)
     end
 
     def validate!

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe OpenapiFirst::Failure do
     end
   end
 
+  describe '#type' do
+    it 'returns the error type' do
+      expect(described_class.new(:invalid_body).type).to eq(:invalid_body)
+    end
+  end
+
+  describe '#type' do
+    it 'returns the error type' do
+      expect(described_class.new(:invalid_body).type).to eq(:invalid_body)
+    end
+  end
+
   describe '#raise!' do
     it 'raises an error' do
       expect do

--- a/spec/middlewares/request_validation_spec.rb
+++ b/spec/middlewares/request_validation_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
 
     it 'adds request to env ' do
       get '/pets'
-      expect(last_request.env[OpenapiFirst::REQUEST]).to be_a OpenapiFirst::RuntimeRequest
+      expect(last_request.env[OpenapiFirst::REQUEST].operation_id).to eq 'listPets'
     end
   end
 

--- a/spec/openapi_first_spec.rb
+++ b/spec/openapi_first_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe OpenapiFirst do
       hash = YAML.safe_load_file('./spec/data/petstore.yaml')
       only = ->(path) { path == '/pets' }
       definition = OpenapiFirst.parse(hash, only:)
-      expected = %w[/pets]
-      expect(definition.paths.keys).to eq expected
+      expect(definition.path('/pets')).to be_truthy
+      expect(definition.path('/pets/{petId}')).to be_nil
     end
 
     it 'loads a Hash' do
@@ -70,13 +70,13 @@ RSpec.describe OpenapiFirst do
       specify 'with empty filter' do
         definition = OpenapiFirst.load(spec_path, only: nil)
         expected = %w[/pets /pets/{id}]
-        expect(definition.paths.keys).to eq expected
+        expect(definition.operations.map(&:path).uniq).to eq expected
       end
 
       specify 'filtering paths' do
         definition = OpenapiFirst.load spec_path, only: ->(path) { path == '/pets' }
         expected = %w[/pets]
-        expect(definition.paths.keys).to eq expected
+        expect(definition.operations.map(&:path).uniq).to eq expected
       end
     end
   end

--- a/spec/runtime_request_spec.rb
+++ b/spec/runtime_request_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
       end
 
       it 'returns Failure' do
-        expect(request.validate.error_type).to eq(:method_not_allowed)
+        expect(request.validate.type).to eq(:method_not_allowed)
       end
     end
   end
 
-  describe '#validation_failure' do
+  describe '#error' do
     it 'is nil by default' do
-      expect(request.validation_failure).to be_nil
+      expect(request.error).to be_nil
     end
 
     context 'with invalid request' do
@@ -67,7 +67,7 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
 
       it 'returns Failure' do
         request.validate
-        expect(request.validation_failure.error_type).to eq(:method_not_allowed)
+        expect(request.error.type).to eq(:method_not_allowed)
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
 
       it 'returns nil' do
         request.validate
-        expect(request.validation_failure).to be_nil
+        expect(request.error).to be_nil
       end
     end
   end
@@ -96,7 +96,7 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
       it 'returns a valid response' do
         result = request.validate_response(rack_response)
         expect(result).to be_valid
-        expect(result.validation_failure).to be_nil
+        expect(result.error).to be_nil
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
       it 'returns an invalid response' do
         result = request.validate_response(rack_response)
         expect(result).not_to be_valid
-        expect(result.validation_failure.error_type).to eq(:invalid_response_body)
+        expect(result.error.type).to eq(:invalid_response_body)
       end
     end
   end

--- a/spec/runtime_request_spec.rb
+++ b/spec/runtime_request_spec.rb
@@ -11,6 +11,108 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
 
   let(:definition) { OpenapiFirst.load('./spec/data/petstore.yaml') }
 
+  describe '#valid?' do
+    context 'with valid request' do
+      let(:rack_request) do
+        Rack::Request.new(Rack::MockRequest.env_for('/pets', method: 'POST', input: '{}'))
+      end
+
+      it 'returns true' do
+        expect(request).to be_valid
+      end
+    end
+
+    context 'with invalid request' do
+      let(:rack_request) do
+        Rack::Request.new(Rack::MockRequest.env_for('/pets/23', method: 'POST', input: '[]'))
+      end
+
+      it 'returns false' do
+        expect(request).not_to be_valid
+      end
+    end
+  end
+
+  describe '#validate' do
+    context 'with valid request' do
+      let(:rack_request) do
+        Rack::Request.new(Rack::MockRequest.env_for('/pets', method: 'POST', input: '{}'))
+      end
+
+      it 'returns nil' do
+        expect(request.validate).to be_nil
+      end
+    end
+
+    context 'with invalid request' do
+      let(:rack_request) do
+        Rack::Request.new(Rack::MockRequest.env_for('/pets/23', method: 'POST', input: '[]'))
+      end
+
+      it 'returns Failure' do
+        expect(request.validate.error_type).to eq(:method_not_allowed)
+      end
+    end
+  end
+
+  describe '#validation_failure' do
+    it 'is nil by default' do
+      expect(request.validation_failure).to be_nil
+    end
+
+    context 'with invalid request' do
+      let(:rack_request) do
+        Rack::Request.new(Rack::MockRequest.env_for('/pets/23', method: 'POST', input: '[]'))
+      end
+
+      it 'returns Failure' do
+        request.validate
+        expect(request.validation_failure.error_type).to eq(:method_not_allowed)
+      end
+    end
+
+    context 'with valid request' do
+      let(:rack_request) do
+        Rack::Request.new(Rack::MockRequest.env_for('/pets', method: 'POST', input: '{}'))
+      end
+
+      it 'returns nil' do
+        request.validate
+        expect(request.validation_failure).to be_nil
+      end
+    end
+  end
+
+  describe '#validate_response' do
+    let(:rack_request) do
+      Rack::Request.new(Rack::MockRequest.env_for('/pets'))
+    end
+
+    let(:rack_response) do
+      Rack::Response.new(JSON.dump([]), 200, { 'Content-Type' => 'application/json' })
+    end
+
+    context 'with valid response' do
+      it 'returns a valid response' do
+        result = request.validate_response(rack_response)
+        expect(result).to be_valid
+        expect(result.validation_failure).to be_nil
+      end
+    end
+
+    context 'with invalid response' do
+      let(:rack_response) do
+        Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns an invalid response' do
+        result = request.validate_response(rack_response)
+        expect(result).not_to be_valid
+        expect(result.validation_failure.error_type).to eq(:invalid_response_body)
+      end
+    end
+  end
+
   describe '#known?' do
     context 'with known path and request method' do
       let(:rack_request) do

--- a/spec/runtime_response_spec.rb
+++ b/spec/runtime_response_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe OpenapiFirst::RuntimeResponse do
       it 'returns a Failure' do
         result = response.validate
         expect(result).to be_a(OpenapiFirst::Failure)
-        expect(result.error_type).to eq :invalid_response_body
+        expect(result.type).to eq :invalid_response_body
       end
     end
   end
@@ -78,11 +78,11 @@ RSpec.describe OpenapiFirst::RuntimeResponse do
     end
   end
 
-  describe '#validation_failure' do
+  describe '#error' do
     context 'if response is valid' do
       it 'returns nil' do
         response.validate
-        expect(response.validation_failure).to be_nil
+        expect(response.error).to be_nil
       end
     end
 
@@ -91,9 +91,9 @@ RSpec.describe OpenapiFirst::RuntimeResponse do
 
       it 'returns a Failure' do
         response.validate
-        result = response.validation_failure
+        result = response.error
         expect(result).to be_a(OpenapiFirst::Failure)
-        expect(result.error_type).to eq :invalid_response_body
+        expect(result.type).to eq :invalid_response_body
       end
     end
   end

--- a/spec/runtime_response_spec.rb
+++ b/spec/runtime_response_spec.rb
@@ -17,6 +17,87 @@ RSpec.describe OpenapiFirst::RuntimeResponse do
 
   let(:definition) { OpenapiFirst.load('./spec/data/petstore.yaml') }
 
+  describe '#validate!' do
+    context 'if response is valid' do
+      it 'returns nil' do
+        expect(response.validate!).to be_nil
+      end
+    end
+
+    context 'if response is invalid' do
+      let(:rack_response) { Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' }) }
+
+      it 'raises ResponseInvalidError' do
+        expect do
+          response.validate!
+        end.to raise_error(OpenapiFirst::ResponseInvalidError)
+      end
+    end
+
+    context 'if request is unknown' do
+      let(:rack_request) { Rack::Request.new(Rack::MockRequest.env_for('/unknown')) }
+      let(:rack_response) { Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' }) }
+
+      it 'skips response validation and returns nil' do
+        expect(response.validate!).to be_nil
+      end
+    end
+  end
+
+  describe 'validate' do
+    context 'if response is valid' do
+      it 'returns nil' do
+        expect(response.validate).to be_nil
+      end
+    end
+
+    context 'if response is invalid' do
+      let(:rack_response) { Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' }) }
+
+      it 'returns a Failure' do
+        result = response.validate
+        expect(result).to be_a(OpenapiFirst::Failure)
+        expect(result.error_type).to eq :invalid_response_body
+      end
+    end
+  end
+
+  describe 'valid?' do
+    context 'if response is valid' do
+      it 'returns true' do
+        expect(response).to be_valid
+      end
+    end
+
+    context 'if response is invalid' do
+      let(:rack_response) { Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' }) }
+
+      it 'returns false' do
+        expect(response).not_to be_valid
+      end
+    end
+  end
+
+  describe '#validation_failure' do
+    context 'if response is valid' do
+      it 'returns nil' do
+        response.validate
+        expect(response.validation_failure).to be_nil
+      end
+    end
+
+    context 'if response is invalid' do
+      let(:rack_response) { Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' }) }
+
+      it 'returns a Failure' do
+        response.validate
+        result = response.validation_failure
+        expect(result).to be_a(OpenapiFirst::Failure)
+        expect(result.error_type).to eq :invalid_response_body
+      end
+    end
+  end
+
   describe '#status' do
     it 'returns the HTTP status code of the response' do
       expect(response.status).to eq(200)
@@ -161,51 +242,6 @@ RSpec.describe OpenapiFirst::RuntimeResponse do
 
       it 'is empty' do
         expect(response.headers).to eq({})
-      end
-    end
-  end
-
-  describe '#validate!' do
-    context 'if response is valid' do
-      it 'returns nil' do
-        expect(response.validate!).to be_nil
-      end
-    end
-
-    context 'if response is invalid' do
-      let(:rack_response) { Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' }) }
-
-      it 'raises ResponseInvalidError' do
-        expect do
-          response.validate!
-        end.to raise_error(OpenapiFirst::ResponseInvalidError)
-      end
-    end
-
-    context 'if request is unknown' do
-      let(:rack_request) { Rack::Request.new(Rack::MockRequest.env_for('/unknown')) }
-      let(:rack_response) { Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' }) }
-
-      it 'skips response validation and returns nil' do
-        expect(response.validate!).to be_nil
-      end
-    end
-  end
-
-  describe 'validate' do
-    context 'if response is valid' do
-      it 'returns nil' do
-        expect(response.validate).to be_nil
-      end
-    end
-
-    context 'if response is invalid' do
-      let(:rack_response) { Rack::Response.new(JSON.dump('foo'), 200, { 'Content-Type' => 'application/json' }) }
-
-      it 'returns a Failure' do
-        result = response.validate
-        expect(result).to be_a(OpenapiFirst::Failure)
-        expect(result.error_type).to eq :invalid_response_body
       end
     end
   end


### PR DESCRIPTION
This adds the interface described in https://github.com/ahx/openapi_first/discussions/221, while keeping the current interface intact.

Instead of running this
```ruby
definition.request(rack_request).validate!
```

you should call this
```ruby
definition.validate_request(rack_request, raise_error: true)
```
