### PR TITLE
Fix handling ActionDispatch::TestResponse in response validation

### DIFF
--- a/lib/openapi_first/failure.rb
+++ b/lib/openapi_first/failure.rb
@@ -53,7 +53,7 @@ module OpenapiFirst
     # @attr_reader [String] message A generic error message
     attr_reader :message
 
-    # @attr_reader [Array<OpenapiFirst::Schema::ValidationError>] errors Validation errors caused by failed Schema validation.
+    # @attr_reader [Array<OpenapiFirst::Schema::ValidationError>] errors Validation errors.
     attr_reader :errors
 
     # Raise an exception that fits the failure.

--- a/lib/openapi_first/runtime_response.rb
+++ b/lib/openapi_first/runtime_response.rb
@@ -85,10 +85,15 @@ module OpenapiFirst
 
     private
 
+    # Usually the body responds to #each, but when using manual response validation without the middleware
+    # in Rails request specs the body is a String. So this code handles both cases.
     def original_body
       buffered_body = String.new
-      @rack_response.body.each { |chunk| buffered_body << chunk }
-      buffered_body
+      if @rack_response.body.respond_to?(:each)
+        @rack_response.body.each { |chunk| buffered_body.to_s << chunk }
+        return buffered_body
+      end
+      @rack_response.body
     end
 
     def load_json(string)

--- a/spec/middlewares/request_validation_spec.rb
+++ b/spec/middlewares/request_validation_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
 
   let(:app) do
     Rack::Builder.app do
+      use Rack::Lint
       use(OpenapiFirst::Middlewares::RequestValidation, spec: File.expand_path('../data/petstore.yaml', __dir__))
+      use Rack::Lint
       run lambda { |_env|
         Rack::Response.new('hello', 200).finish
       }

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
 
   let(:app) do
     Rack::Builder.app do
+      use Rack::Lint
       use(OpenapiFirst::Middlewares::ResponseValidation, spec: File.expand_path('../data/petstore.yaml', __dir__))
+      use Rack::Lint
       run lambda { |_env|
         Rack::Response.new('[]', 200, { 'Content-Type' => 'application/json' }).finish
       }

--- a/spec/runtime_response_spec.rb
+++ b/spec/runtime_response_spec.rb
@@ -153,6 +153,17 @@ RSpec.describe OpenapiFirst::RuntimeResponse do
         expect(response.body).to eq('foo' => 'bar')
       end
     end
+
+    context 'when using Rails tests' do
+      let(:rack_response) do
+        app_response = Rack::Response.new(JSON.dump({ foo: :bar }), 200, { 'Content-Type' => 'application/json' })
+        ActionDispatch::TestResponse.from_response(app_response)
+      end
+
+      it 'returns the parsed body' do
+        expect(response.body).to eq('foo' => 'bar')
+      end
+    end
   end
 
   describe '#name' do


### PR DESCRIPTION
I noticed that manual response validation broke in Rails' request spec. 

```ruby
NoMethodError:
       undefined method `each' for "[]":String
```

This is because ActionDispatch::TestResponse#body returns a String.
This change should fix that.
