### PR TITLE
Resolve warning about duplicate constant assignment

### DIFF
--- a/lib/openapi_first/definition/operation.rb
+++ b/lib/openapi_first/definition/operation.rb
@@ -157,8 +157,6 @@ module OpenapiFirst
 
       private
 
-      WRITE_METHODS = Set.new(%w[post put patch delete]).freeze
-
       IGNORED_HEADERS = Set['Content-Type', 'Accept', 'Authorization'].freeze
 
       def all_parameters


### PR DESCRIPTION
Getting rid of the annoying warning introduced in 1.3.0 caused by duplicate constant assignment:

/Users/bijan/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/openapi_first-1.3.0/lib/openapi_first/definition/operation.rb:160: warning: already initialized constant OpenapiFirst::Definitio
n::Operation::WRITE_METHODS
/Users/bijan/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/openapi_first-1.3.0/lib/openapi_first/definition/operation.rb:20: warning: previous definition of WRITE_METHODS was here
