### PR TITLE
Support integer status, even OAS does only allow string status codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added: The response definition is found if the status is defined as an Integer instead of String.
 - Chore: Add Readme back to gem. Link to docs.
 - Middlewares now have an `#app` method for easier subclassing
 

--- a/lib/openapi_first/definition/responses.rb
+++ b/lib/openapi_first/definition/responses.rb
@@ -66,6 +66,10 @@ module OpenapiFirst
       end
 
       def find_response_object(status)
+        # According to OAS status has to be a string,
+        # but there are a few API descriptions out there that use integers because of YAML.
+        return @responses_object[status] if @responses_object.key?(status)
+
         @responses_object[status.to_s] ||
           @responses_object["#{status / 100}XX"] ||
           @responses_object["#{status / 100}xx"] ||

--- a/spec/runtime_request_spec.rb
+++ b/spec/runtime_request_spec.rb
@@ -411,6 +411,43 @@ RSpec.describe OpenapiFirst::RuntimeRequest do
     end
   end
 
+  describe '#response' do
+    let(:response) { Rack::Response.new('', 200, { 'Content-Type' => 'application/json' }) }
+
+    it 'returns a Definition::RuntimeResponse' do
+      result = request.response(response)
+      expect(result).to be_a(OpenapiFirst::RuntimeResponse)
+      expect(result.description).to eq('Expected response to a valid request')
+    end
+
+    context 'when API description has integers as status' do
+      let(:definition) do
+        hash = {
+          'openapi' => '3.1.0',
+          'paths' => {
+            '/pets/{petId}' => {
+              'parameters' => [
+                { 'name' => 'petId', 'in' => 'path', 'required' => true, 'schema' => { 'type' => 'integer' } }
+              ],
+              'get' => {
+                'responses' => {
+                  200 => { 'description' => 'Expected response to a valid request' }
+                }
+              }
+            }
+          }
+        }
+        OpenapiFirst.parse(hash)
+      end
+
+      it 'just works, even though OAS wants strings' do
+        result = request.response(response)
+        expect(result).to be_a(OpenapiFirst::RuntimeResponse)
+        expect(result.description).to eq('Expected response to a valid request')
+      end
+    end
+  end
+
   describe '#operation' do
     it 'returns the request operation' do
       expect(request.operation.path).to eq('/pets/{petId}')


### PR DESCRIPTION
There are a few API description out there that use integers because of YAML