### PR TITLE
Use inline forked version of json_refs gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ Style/Documentation:
   Exclude:
     - "spec/**/*"
     - "benchmarks/**/*"
+    - "lib/openapi_first/json_refs.rb"
 Style/ExponentialNotation:
   Enabled: true
 Metrics/BlockLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Fixed: Use forked version of json_refs which does not call chdir, which causes a problem in threaded environments
 - Added: The response definition is found if the status is defined as an Integer instead of String.
 - Chore: Add Readme back to gem. Link to docs.
 - Middlewares now have an `#app` method for easier subclassing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Fixed: Use forked version of json_refs which does not call chdir, which causes a problem in threaded environments
+- Fixed: No longer use chdir when, resolving splitted files, which causes a problem in threaded environments
 - Added: The response definition is found if the status is defined as an Integer instead of String.
 - Chore: Add Readme back to gem. Link to docs.
 - Middlewares now have an `#app` method for easier subclassing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     openapi_first (1.3.1)
-      json_refs (~> 0.1, >= 0.1.7)
+      hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
       mustermann (~> 3.0.0)
@@ -54,8 +54,6 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    json_refs (0.1.8)
-      hana
     json_schemer (2.1.1)
       hana (~> 1.3)
       regexp_parser (~> 2.0)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     openapi_first (1.3.1)
-      json_refs (~> 0.1, >= 0.1.7)
+      hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
       mustermann (~> 3.0.0)
@@ -21,8 +21,6 @@ GEM
       openapi_parser (~> 2.0)
       rack (>= 1.5)
     hana (1.3.7)
-    json_refs (0.1.8)
-      hana
     json_schema (0.21.0)
     json_schemer (2.1.1)
       hana (~> 1.3)

--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -2,7 +2,7 @@
 
 require 'yaml'
 require 'multi_json'
-require 'json_refs'
+require_relative 'openapi_first/json_refs'
 require_relative 'openapi_first/errors'
 require_relative 'openapi_first/configuration'
 require_relative 'openapi_first/plugins'
@@ -35,7 +35,7 @@ module OpenapiFirst
   # Load and dereference an OpenAPI spec file
   # @return [Definition]
   def self.load(filepath, only: nil)
-    resolved = bundle(filepath)
+    resolved = Bundle.resolve(filepath)
     parse(resolved, only:, filepath:)
   end
 
@@ -47,23 +47,9 @@ module OpenapiFirst
   end
 
   # @!visibility private
-  def self.bundle(filepath)
-    Bundle.resolve(filepath)
-  end
-
-  # @!visibility private
   module Bundle
     def self.resolve(spec_path)
-      Dir.chdir(File.dirname(spec_path)) do
-        content = load_file(File.basename(spec_path))
-        JsonRefs.call(content, resolve_local_ref: true, resolve_file_ref: true)
-      end
-    end
-
-    def self.load_file(spec_path)
-      return MultiJson.load(File.read(spec_path)) if File.extname(spec_path) == '.json'
-
-      YAML.unsafe_load_file(spec_path)
+      JsonRefs.load(spec_path)
     end
   end
 end

--- a/lib/openapi_first/json_refs.rb
+++ b/lib/openapi_first/json_refs.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# This is a fork of the json_refs gem with some simplifications.
+# The original code is available at https://github.com/tzmfreedom/json_refs
+# This is a simplified version, which does not use chdir. See also https://github.com/tzmfreedom/json_refs/pull/11
+# The code was originally written by Makoto Tajitsu with the MIT License.
+#
+# The MIT License (MIT)
+
+# Copyright (c) 2017 Makoto Tajitsu
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'hana'
+require 'json'
+require 'yaml'
+
+module JsonRefs
+  class << self
+    def call(doc)
+      Dereferencer.new(Dir.pwd, doc).call
+    end
+
+    alias dereference call
+
+    def load(filename)
+      doc_dir = File.dirname(filename)
+      doc = Loader.handle(filename)
+      Dereferencer.new(doc_dir, doc).call
+    end
+  end
+
+  module LocalRef
+    module_function
+
+    def call(path:, doc:)
+      Hana::Pointer.new(path[1..]).eval(doc)
+    end
+  end
+
+  module Loader
+    module_function
+
+    def handle(filename)
+      body = File.read(filename)
+      return JSON.parse(body) if File.extname(filename) == '.json'
+
+      YAML.unsafe_load(body)
+    end
+  end
+
+  class Dereferencer
+    def initialize(doc_dir, doc)
+      @doc = doc
+      @doc_dir = doc_dir
+    end
+
+    def call(doc = @doc, keys = [])
+      if doc.is_a?(Array)
+        doc.each_with_index do |value, idx|
+          call(value, keys + [idx])
+        end
+      elsif doc.is_a?(Hash)
+        if doc.key?('$ref')
+          dereference(keys, doc['$ref'])
+        else
+          doc.each do |key, value|
+            call(value, keys + [key])
+          end
+        end
+      end
+      doc
+    end
+
+    private
+
+    attr_reader :doc_dir
+
+    def dereference(paths, referenced_path)
+      key = paths.pop
+      target = paths.inject(@doc) do |obj, k|
+        obj[k]
+      end
+      value = follow_referenced_value(referenced_path)
+      target[key] = value
+    end
+
+    def follow_referenced_value(referenced_path)
+      value = referenced_value(referenced_path)
+      return referenced_value(value['$ref']) if value.is_a?(Hash) && value.key?('$ref')
+
+      value
+    end
+
+    def referenced_value(referenced_path)
+      filepath, pointer = referenced_path.split('#')
+      pointer&.prepend('#')
+      return dereference_local(pointer) if filepath.empty?
+
+      dereferenced_file = dereference_file(filepath)
+      return dereferenced_file if pointer.nil?
+
+      LocalRef.call(
+        path: pointer,
+        doc: dereferenced_file
+      )
+    end
+
+    def dereference_local(referenced_path)
+      LocalRef.call(path: referenced_path, doc: @doc)
+    end
+
+    def dereference_file(referenced_path)
+      referenced_path = "#{doc_dir}/#{referenced_path}" unless File.absolute_path?(referenced_path)
+      directory = File.dirname(referenced_path)
+
+      referenced_doc = Loader.handle(referenced_path)
+      Dereferencer.new(directory, referenced_doc).call
+    end
+  end
+end

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.1.1'
 
-  spec.add_runtime_dependency 'json_refs', '~> 0.1', '>= 0.1.7'
+  spec.add_runtime_dependency 'hana', '~> 1.3'
   spec.add_runtime_dependency 'json_schemer', '~> 2.1.0'
   spec.add_runtime_dependency 'multi_json', '~> 1.15'
   spec.add_runtime_dependency 'mustermann', '~> 3.0.0'


### PR DESCRIPTION
because the original gem author is currently not responding to issues.

This version does not use chdir, which leads  to problems in threaded environments.

See also https://github.com/tzmfreedom/json_refs/pull/11