### PR TITLE
1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
 ## Unreleased
-- Fixed: No longer use chdir when, resolving splitted files, which causes a problem in threaded environments
-- Added: The response definition is found if the status is defined as an Integer instead of String.
-- Chore: Add Readme back to gem. Link to docs.
-- Middlewares now have an `#app` method for easier subclassing
+
+## 1.3.2
+
+### Changed
+
+- The response definition is found even if the status is defined as an Integer instead of a String. This is not provided for in the OAS specification, but is often done this way, because of YAML.
+
+### Fixed
+
+- Reduced initial load time for composed API descriptions [#232](https://github.com/ahx/openapi_first/pull/232)
+- Chore: Add Readme back to gem. Add link to docs.
 
 ## 1.3.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (1.3.1)
+    openapi_first (1.3.2)
       hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
@@ -67,9 +67,9 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
-    nokogiri (1.16.0-arm64-darwin)
+    nokogiri (1.16.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.0-x86_64-linux)
+    nokogiri (1.16.1-x86_64-linux)
       racc (~> 1.4)
     openapi_parameters (0.3.2)
       rack (>= 2.2)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (1.3.1)
+    openapi_first (1.3.2)
       hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
@@ -37,7 +37,7 @@ GEM
     openapi_parser (2.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
-    rack (3.0.8)
+    rack (3.0.9)
     rack-protection (4.0.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0, < 4)

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end


### PR DESCRIPTION
Highlights:

- Initial loading got much faster for composite API descriptions
- It just works if your YAML file says `200:` instead of `'200':` (as provided by the OAS)
