### PR TITLE
Cach the resolved file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Cache the resolved OAD. This especially makes things run faster in tests.
+
 ## 1.3.2
 
 ### Changed

--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -49,7 +49,8 @@ module OpenapiFirst
   # @!visibility private
   module Bundle
     def self.resolve(spec_path)
-      JsonRefs.load(spec_path)
+      @file_cache ||= {}
+      @file_cache[File.expand_path(spec_path).to_sym] ||= JsonRefs.load(spec_path)
     end
   end
 end


### PR DESCRIPTION
This especially makes a difference when running  tests.