### PR TITLE
1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.3.5
+
 - Added support for `/some/{kebab-cased}` path parameters ([#245](https://github.com/ahx/openapi_first/issues/245))
 
 ## 1.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (1.3.4)
+    openapi_first (1.3.5)
       hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
@@ -63,9 +63,9 @@ GEM
     minitest (5.22.3)
     multi_json (1.15.0)
     mutex_m (0.2.0)
-    nokogiri (1.16.2-arm64-darwin)
+    nokogiri (1.16.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.16.3-x86_64-linux)
       racc (~> 1.4)
     openapi_parameters (0.3.2)
       rack (>= 2.2)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (1.3.4)
+    openapi_first (1.3.5)
       hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '1.3.4'
+  VERSION = '1.3.5'
 end


### PR DESCRIPTION
Added support for `/some/{kebab-cased}` path parameters ([#245](https://github.com/ahx/openapi_first/issues/245))