### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 ## Unreleased
 
+## 1.4.0
+
 ### Changed
+
+Some redundant methods to validate or inspect requests/responses will be removed in 2.0. So this release deprecates these methods.
 
 - Deprecate `OpenapiFirst::RuntimeRequest#validate`, `#validate!`, `#validate_response`, `#response`.
   Use `OpenapiFirst.load('openapi.yaml').validate_request(rack_request, raise_error: true/false)` instead
 - Deprecate `OpenapiFirst::RuntimeResponse#validate`.
   Use `OpenapiFirst.load('openapi.yaml').validate_response(rack_request, rack_response, raise_error: true/false)` instead.
-
-These deprecated methods will be removed in version 2.0.
 
 ## 1.3.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Changed
+
+- Deprecate `OpenapiFirst::RuntimeRequest#validate`, `#validate!`, `#validate_response`, `#response`.
+  Use `OpenapiFirst.load('openapi.yaml').validate_request(rack_request, raise_error: true/false)` instead
+- Deprecate `OpenapiFirst::RuntimeResponse#validate`.
+  Use `OpenapiFirst.load('openapi.yaml').validate_response(rack_request, rack_response, raise_error: true/false)` instead.
+
+These deprecated methods will be removed in version 2.0.
+
 ## 1.3.6
 
 - FIx Rack 2 / Rails 6 compatibility ([#246](https://github.com/ahx/openapi_first/issues/246)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (1.3.6)
+    openapi_first (1.4.0)
       hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
@@ -51,7 +51,7 @@ GEM
     hana (1.3.7)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    json (2.7.1)
+    json (2.7.2)
     json_schemer (2.1.1)
       hana (~> 1.3)
       regexp_parser (~> 2.0)
@@ -91,7 +91,7 @@ GEM
       loofah (~> 2.21)
       nokogiri (~> 1.14)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     regexp_parser (2.9.0)
     rexml (3.2.6)
     rspec (3.13.0)

--- a/Gemfile.rack2.lock
+++ b/Gemfile.rack2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (1.3.6)
+    openapi_first (1.4.0)
       hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
@@ -51,7 +51,7 @@ GEM
     hana (1.3.7)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    json (2.7.1)
+    json (2.7.2)
     json_schemer (2.1.1)
       hana (~> 1.3)
       regexp_parser (~> 2.0)
@@ -92,7 +92,7 @@ GEM
       loofah (~> 2.21)
       nokogiri (~> 1.14)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     regexp_parser (2.9.0)
     rexml (3.2.6)
     rspec (3.13.0)

--- a/Gemfile.rails6.lock
+++ b/Gemfile.rails6.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (1.3.6)
+    openapi_first (1.4.0)
       hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
@@ -40,7 +40,7 @@ GEM
     hana (1.3.7)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    json (2.7.1)
+    json (2.7.2)
     json_schemer (2.1.1)
       hana (~> 1.3)
       regexp_parser (~> 2.0)
@@ -85,7 +85,7 @@ GEM
       loofah (~> 2.21)
       nokogiri (~> 1.14)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     regexp_parser (2.9.0)
     rexml (3.2.6)
     rspec (3.13.0)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (1.3.6)
+    openapi_first (1.4.0)
       hana (~> 1.3)
       json_schemer (~> 2.1.0)
       multi_json (~> 1.15)
@@ -33,7 +33,7 @@ GEM
     openapi_parameters (0.3.2)
       rack (>= 2.2)
       zeitwerk (~> 2.6)
-    openapi_parser (2.0.0)
+    openapi_parser (2.1.0)
     puma (6.4.2)
       nio4r (~> 2.0)
     rack (3.0.10)

--- a/lib/openapi_first/middlewares/request_validation.rb
+++ b/lib/openapi_first/middlewares/request_validation.rb
@@ -26,21 +26,15 @@ module OpenapiFirst
       attr_reader :app
 
       def call(env)
-        request = find_request(env)
-        return @app.call(env) unless request
-
-        failure = request.validate
-        failure.raise! if failure && @raise
+        validated = @definition.validate_request(Rack::Request.new(env), raise_error: @raise)
+        env[REQUEST] ||= validated
+        failure = validated.error
         return @error_response_class.new(failure:).render if failure
 
         @app.call(env)
       end
 
       private
-
-      def find_request(env)
-        env[REQUEST] ||= @definition.request(Rack::Request.new(env))
-      end
 
       def error_response(mod)
         return OpenapiFirst.find_plugin(mod)::ErrorResponse if mod.is_a?(Symbol)

--- a/lib/openapi_first/middlewares/response_validation.rb
+++ b/lib/openapi_first/middlewares/response_validation.rb
@@ -22,10 +22,10 @@ module OpenapiFirst
       attr_reader :app
 
       def call(env)
-        request = find_request(env)
         status, headers, body = @app.call(env)
         body = read_body(body)
-        request.validate_response(Rack::Response[status, headers, body], raise_error: true)
+        @definition.validate_response(Rack::Request.new(env), Rack::Response[status, headers, body], raise_error: true)
+        env[REQUEST] ||= @definition.request(Rack::Request.new(env))
         [status, headers, body]
       end
 
@@ -37,10 +37,6 @@ module OpenapiFirst
         result = []
         body.each { |part| result << part }
         result
-      end
-
-      def find_request(env)
-        env[REQUEST] ||= @definition.request(Rack::Request.new(env))
       end
     end
   end

--- a/lib/openapi_first/runtime_request.rb
+++ b/lib/openapi_first/runtime_request.rb
@@ -120,13 +120,18 @@ module OpenapiFirst
 
     # Validates the request.
     # @return [Failure, nil] The Failure object if validation failed.
+    # @deprecated Please use {Definition#validate_request} instead
     def validate
+      warn '[DEPRECATION] `validate` is deprecated. Please use ' \
+           "`OpenapiFirst.load('openapi.yaml').validate_request(rack_request)` instead."
       @validated = true
       @error = RequestValidation::Validator.new(operation).validate(self)
     end
 
     # Validates the request and raises an error if validation fails.
     def validate!
+      warn '[DEPRECATION] `validate!` is deprecated. Please use ' \
+           "`OpenapiFirst.load('openapi.yaml').validate_request(rack_request, raise_error: true)` instead."
       error = validate
       error&.raise!
     end
@@ -136,6 +141,8 @@ module OpenapiFirst
     # @param raise_error [Boolean] Whether to raise an error if validation fails.
     # @return [RuntimeResponse] The validated response object.
     def validate_response(rack_response, raise_error: false)
+      warn '[DEPRECATION] `validate_response!` is deprecated. Please use ' \
+           "`OpenapiFirst.load('openapi.yaml').validate_response(request, response, raise_error: false)` instead."
       validated = response(rack_response).tap(&:validate)
       validated.error&.raise! if raise_error
       validated
@@ -145,6 +152,8 @@ module OpenapiFirst
     # @param rack_response [Rack::Response] The rack response object.
     # @return [RuntimeResponse] The RuntimeResponse object.
     def response(rack_response)
+      warn '[DEPRECATION] `response` is deprecated. Please use ' \
+           "`OpenapiFirst.load('openapi.yaml').validate_response(request, response, raise_error: false)` instead."
       RuntimeResponse.new(operation, rack_response)
     end
 

--- a/lib/openapi_first/runtime_response.rb
+++ b/lib/openapi_first/runtime_response.rb
@@ -67,7 +67,10 @@ module OpenapiFirst
 
     # Validates the response.
     # @return [Failure, nil] Returns the validation error, or nil if the response is valid.
+    # @deprecated Please use {Definition#validate_response} instead
     def validate
+      warn '[DEPRECATION] `validate` is deprecated. ' \
+           "Please use `OpenapiFirst.load('openapi.yaml').validate_response(rack_request, rack_response)` instead."
       @validated = true
       @error = ResponseValidation::Validator.new(@operation).validate(self)
     end

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '1.3.6'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
Some redundant methods to validate or inspect requests/responses will be removed in 2.0. So this release deprecates these methods.


The main interface as described in the Readme is unchanged.
