### PR TITLE
Bump json_schemer from 2.1.0 to 2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     openapi_first (1.4.2)
       hana (~> 1.3)
-      json_schemer (~> 2.1.0)
+      json_schemer (~> 2.2.0)
       multi_json (~> 1.15)
       openapi_parameters (>= 0.3.3, < 2.0)
       rack (>= 2.2, < 4.0)
@@ -39,7 +39,7 @@ GEM
       tzinfo (~> 2.0)
     ast (2.4.2)
     base64 (0.2.0)
-    bigdecimal (3.1.7)
+    bigdecimal (3.1.8)
     builder (3.2.4)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -49,10 +49,12 @@ GEM
     drb (2.2.1)
     erubi (1.12.0)
     hana (1.3.7)
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
-    json_schemer (2.1.1)
+    json_schemer (2.2.1)
+      base64
+      bigdecimal
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
@@ -65,12 +67,10 @@ GEM
     mutex_m (0.2.0)
     nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.4-x86_64-linux)
-      racc (~> 1.4)
     openapi_parameters (0.3.3)
       rack (>= 2.2)
     parallel (1.24.0)
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
@@ -106,7 +106,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.63.2)
+    rubocop (1.63.4)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -117,8 +117,8 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -126,7 +126,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    simpleidn (0.2.1)
+    simpleidn (0.2.2)
       unf (~> 0.1.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -139,6 +139,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1.1'
 
   spec.add_runtime_dependency 'hana', '~> 1.3'
-  spec.add_runtime_dependency 'json_schemer', '~> 2.1.0'
+  spec.add_runtime_dependency 'json_schemer', '~> 2.2.0'
   spec.add_runtime_dependency 'multi_json', '~> 1.15'
   spec.add_runtime_dependency 'openapi_parameters', '>= 0.3.3', '< 2.0'
   spec.add_runtime_dependency 'rack', '>= 2.2', '< 4.0'

--- a/spec/json_schema_spec.rb
+++ b/spec/json_schema_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe OpenapiFirst::Schema do
       expect(error.instance_location).to eq('/data/additional')
       expect(error.schema_location).to eq('/properties/data/additionalProperties')
       expect(error.error).to eq(
-        'object property at `/data/additional` is not defined and schema does not allow additional properties'
+        'object property at `/data/additional` is a disallowed additional property'
       )
       expect(error.type).to eq('schema')
       expect(error.details).to be_nil


### PR DESCRIPTION
I'm trying to use this gem for validating my OpenAPI schema against the responses from my controllers by replacing committee with this gem. I'm also using the [activerecord_json_validator](https://github.com/mirego/activerecord_json_validator) gem which requires `json_schemer ~> 2.2.0`. Currently, openapi_first requires `json_schemer ~> 2.1.0` which is causing a mismatch in my dependencies. I am currently using version 3.0.0 of `activerecord_json_validator`. Unfortunately, there is no way to use `json_schemer` 2.1.0 with version 3.x of `activerecord_json_validator` since 3.0.0 of `activerecord_json_validator` requires `json_schemer` 2.1.x.

As such, I've updated the version of `json_schemer` in this gem to resolve this conflict if you're trying to use this gem together with version 3.0.0 of `activerecord_json_validator`.

As far as I can tell, the version of `json_schemer` can be safely updated to 2.2.0 (see changelog [here](https://github.com/davishmcclurg/json_schemer/blob/main/CHANGELOG.md#220---2024-03-02)). The only change that affects this library is the change in the validation error message for `additionalProperties` as changed in [this commit](https://github.com/davishmcclurg/json_schemer/commit/e8750cf682f94718c2188e6d3867d45e5d66ca73). As such, I've updated the spec to reflect this change.

Let me know if any other changes are required.