### PR TITLE
Add a middleware option to skip rendering a response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Request validation middleware now accepts `error_response: false` do disable rendering a response. This is useful if you just want to collect metrics (via hooks) during a migration phase.
+
 ## 2.0.2
 
 - Fix setting custom error response (thanks @gobijan)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ use OpenapiFirst::Middlewares::RequestValidation, spec: 'openapi.yaml'
 | :---------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `spec:`           |                                                                          | The path to the spec file or spec loaded via `OpenapiFirst.load`                                                                    |
 | `raise_error:`    | `false` (default), `true`                                                | If set to true the middleware raises `OpenapiFirst::RequestInvalidError` or `OpenapiFirst::NotFoundError` instead of returning 4xx. |
-| `error_response:` | `:default` (default), `:jsonapi`, Your implementation of `ErrorResponse` |
+| `error_response:` | `:default` (default), `:jsonapi`, Your implementation of `ErrorResponse` or `false` to disable responding  |
 
 #### Error responses
 

--- a/lib/openapi_first/middlewares/request_validation.rb
+++ b/lib/openapi_first/middlewares/request_validation.rb
@@ -10,11 +10,13 @@ module OpenapiFirst
       #   :raise_error    A Boolean indicating whether to raise an error if validation fails.
       #                   default: false
       #   :error_response The Class to use for error responses.
+      #                   This can be a Symbol-name of an registered error response (:default, :jsonapi)
+      #                   or it can be set to false to disable returning a response.
       #                   default: OpenapiFirst::Plugins::Default::ErrorResponse (Config.default_options.error_response)
       def initialize(app, options = {})
         @app = app
         @raise = options.fetch(:raise_error, OpenapiFirst.configuration.request_validation_raise_error)
-        @error_response_class = error_response(options[:error_response])
+        @error_response_class = error_response_option(options[:error_response])
 
         spec = options.fetch(:spec)
         raise "You have to pass spec: when initializing #{self.class}" unless spec
@@ -29,17 +31,18 @@ module OpenapiFirst
         validated = @definition.validate_request(Rack::Request.new(env), raise_error: @raise)
         env[REQUEST] = validated
         failure = validated.error
-        return @error_response_class.new(failure:).render if failure
+        return @error_response_class.new(failure:).render if failure && @error_response_class
 
         @app.call(env)
       end
 
       private
 
-      def error_response(mod)
-        return OpenapiFirst.find_error_response(mod) if mod.is_a?(Symbol)
+      def error_response_option(value)
+        return if value == false
+        return OpenapiFirst.find_error_response(value) if value.is_a?(Symbol)
 
-        mod || OpenapiFirst.configuration.request_validation_error_response
+        value || OpenapiFirst.configuration.request_validation_error_response
       end
     end
   end


### PR DESCRIPTION
This can be useful if you silently want validate all requests, maybe during a migration phase.