### PR TITLE
Use JSONSchemer::Openapi#ref to get response body schema from main OAD. Fixes discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix support for discriminator in response body validation (https://github.com/ahx/openapi_first/issues/285)
 - Replace bundled json_refs fork with own code
 
 ## 2.1.1

--- a/lib/openapi_first/json_pointer.rb
+++ b/lib/openapi_first/json_pointer.rb
@@ -4,7 +4,7 @@ module OpenapiFirst
   # Functions to handle JSON Pointers
   # @!visibility private
   module JsonPointer
-    ESCAPE_CHARS = { '~' => '~0', '/' => '~1', '+' => '%2B' }
+    ESCAPE_CHARS = { '~' => '~0', '/' => '~1', '+' => '%2B' }.freeze
     ESCAPE_REGEX = Regexp.union(ESCAPE_CHARS.keys)
 
     module_function

--- a/lib/openapi_first/json_pointer.rb
+++ b/lib/openapi_first/json_pointer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  # Functions to handle JSON Pointers
+  # @!visibility private
+  module JsonPointer
+    ESCAPE_CHARS = { '~' => '~0', '/' => '~1', '+' => '%2B' }
+    ESCAPE_REGEX = Regexp.union(ESCAPE_CHARS.keys)
+
+    module_function
+
+    def append(root, *tokens)
+      "#{root}/" + tokens.map do |token|
+        escape_json_pointer_token(token)
+      end.join('/')
+    end
+
+    def escape_json_pointer_token(token)
+      token.gsub(ESCAPE_REGEX, ESCAPE_CHARS)
+    end
+  end
+end

--- a/lib/openapi_first/refs.rb
+++ b/lib/openapi_first/refs.rb
@@ -28,7 +28,8 @@ module OpenapiFirst
     end
 
     def resolve_data!(data, context:, dir:)
-      if data.is_a?(Hash)
+      case data
+      when Hash
         return data if data.key?('discriminator')
 
         if data.key?('$ref')
@@ -38,7 +39,7 @@ module OpenapiFirst
         data.transform_values! do |value|
           resolve_data!(value, context:, dir:)
         end
-      elsif data.is_a?(Array)
+      when Array
         data.map! do |value|
           resolve_data!(value, context:, dir:)
         end

--- a/lib/openapi_first/refs.rb
+++ b/lib/openapi_first/refs.rb
@@ -29,6 +29,8 @@ module OpenapiFirst
 
     def resolve_data!(data, context:, dir:)
       if data.is_a?(Hash)
+        return data if data.key?('discriminator')
+
         if data.key?('$ref')
           referenced_value = resolve_ref(data.delete('$ref'), context:, dir:)
           data.merge!(referenced_value) if referenced_value.is_a?(Hash)

--- a/lib/openapi_first/validators/response_body.rb
+++ b/lib/openapi_first/validators/response_body.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
+require_relative '../schema/validation_result'
+
 module OpenapiFirst
   module Validators
     class ResponseBody
-      def self.for(response_definition, openapi_version:)
+      def self.for(response_definition, **)
         schema = response_definition&.content_schema
         return unless schema
 
-        new(Schema.new(schema, write: false, openapi_version:))
+        new(schema)
       end
 
       def initialize(schema)
@@ -22,7 +24,9 @@ module OpenapiFirst
         rescue ParseError => e
           Failure.fail!(:invalid_response_body, message: e.message)
         end
-        validation = schema.validate(parsed_body)
+        validation = Schema::ValidationResult.new(
+          schema.validate(parsed_body, access_mode: 'read')
+        )
         Failure.fail!(:invalid_response_body, errors: validation.errors) if validation.error?
       end
     end

--- a/spec/data/discriminator-refs.yaml
+++ b/spec/data/discriminator-refs.yaml
@@ -1,0 +1,46 @@
+---
+openapi: 3.1.0
+info:
+  title: API V1
+  version: v1
+paths:
+  "/pets":
+    get:
+      summary: Pets
+      responses:
+        "200":
+          description: successful
+          content:
+            application/json:
+              schema:
+                items:
+                  oneOf:
+                    - "$ref": "#/components/schemas/cat"
+                    - "$ref": "#/components/schemas/dog"
+                  discriminator:
+                    propertyName: petType
+                type: array
+components:
+  schemas:
+    cat:
+      type: object
+      properties:
+        id:
+          type: integer
+        petType:
+          type: string
+          enum:
+            - cat
+        meow:
+          type: string
+    dog:
+      type: object
+      properties:
+        id:
+          type: integer
+        petType:
+          type: string
+          enum:
+            - dog
+        bark:
+          type: string

--- a/spec/json_pointer_spec.rb
+++ b/spec/json_pointer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::JsonPointer do
+  describe '.append' do
+    it 'escapes tilde and slash' do
+      result = described_class.append('#', '/stations', '~italy')
+      expect(result).to eq('#/~1stations/~0italy')
+    end
+
+    it 'URL escapes plus' do
+      result = described_class.append('#', '/responses', 'content', 'application/problem+json')
+      expect(result).to eq('#/~1responses/content/application~1problem%2Bjson')
+    end
+
+    it 'does not escape the first token' do
+      result = described_class.append('#/paths', '/stations', 'responses')
+      expect(result).to eq('#/paths/~1stations/responses')
+    end
+  end
+end

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -298,6 +298,33 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
     end
   end
 
+  context 'with discriminator' do
+    let(:spec) { './spec/data/discriminator-refs.yaml' }
+
+    context 'with an invalid response' do
+      let(:response_body) { json_dump([{ id: 1, petType: 'unknown', meow: 'Huh' }]) }
+
+      it 'fails' do
+        get '/pets'
+      end
+    end
+
+    context 'with a valid response' do
+      let(:response_body) do
+        json_dump([
+          { id: 1, petType: 'cat', meow: 'Prrr' },
+          { id: 2, petType: 'dog', bark: 'Woof' }
+        ])
+      end
+
+      it 'succeeds' do
+        get '/pets'
+
+        expect(last_response.status).to eq(200)
+      end
+    end
+  end
+
   describe 'response header validation' do
     let(:app) do
       Rack::Builder.app do

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -305,16 +305,18 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
       let(:response_body) { json_dump([{ id: 1, petType: 'unknown', meow: 'Huh' }]) }
 
       it 'fails' do
-        get '/pets'
+        expect do
+          get '/pets'
+        end.to raise_error(OpenapiFirst::ResponseInvalidError)
       end
     end
 
     context 'with a valid response' do
       let(:response_body) do
         json_dump([
-          { id: 1, petType: 'cat', meow: 'Prrr' },
-          { id: 2, petType: 'dog', bark: 'Woof' }
-        ])
+                    { id: 1, petType: 'cat', meow: 'Prrr' },
+                    { id: 2, petType: 'dog', bark: 'Woof' }
+                  ])
       end
 
       it 'succeeds' do

--- a/spec/response_validator_spec.rb
+++ b/spec/response_validator_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe OpenapiFirst::ResponseValidator do
     end
   end
 
-  describe 'invalid response' do
+  context 'with an invalid response' do
     context 'with missing property' do
       let(:parsed_response) do
         double(

--- a/spec/response_validator_spec.rb
+++ b/spec/response_validator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OpenapiFirst::ResponseValidator do
     response_definition = instance_double(OpenapiFirst::Response,
                                           status: '200',
                                           content_type: 'application/json',
-                                          content_schema: {
+                                          content_schema: JSONSchemer.schema({
                                             'type' => 'array',
                                             'items' => {
                                               'type' => 'object',
@@ -16,7 +16,7 @@ RSpec.describe OpenapiFirst::ResponseValidator do
                                                 'tag' => { 'type' => 'string' }
                                               }
                                             }
-                                          },
+                                          }),
                                           headers: {},
                                           headers_schema: nil)
     described_class.new(response_definition, openapi_version: '3.1')

--- a/spec/response_validator_spec.rb
+++ b/spec/response_validator_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe OpenapiFirst::ResponseValidator do
                                           status: '200',
                                           content_type: 'application/json',
                                           content_schema: JSONSchemer.schema({
-                                            'type' => 'array',
-                                            'items' => {
-                                              'type' => 'object',
-                                              'required' => %w[id name],
-                                              'properties' => {
-                                                'id' => { 'type' => 'integer' },
-                                                'name' => { 'type' => 'string' },
-                                                'tag' => { 'type' => 'string' }
-                                              }
-                                            }
-                                          }),
+                                                                               'type' => 'array',
+                                                                               'items' => {
+                                                                                 'type' => 'object',
+                                                                                 'required' => %w[id name],
+                                                                                 'properties' => {
+                                                                                   'id' => { 'type' => 'integer' },
+                                                                                   'name' => { 'type' => 'string' },
+                                                                                   'tag' => { 'type' => 'string' }
+                                                                                 }
+                                                                               }
+                                                                             }),
                                           headers: {},
                                           headers_schema: nil)
     described_class.new(response_definition, openapi_version: '3.1')


### PR DESCRIPTION
This should resolve https://github.com/ahx/openapi_first/issues/285

The idea is to do the same for all schemas if possible

