### PR TITLE
Fix broken `Gemfile.lock` in the example app

### DIFF
--- a/examples/rails_app/Gemfile.lock
+++ b/examples/rails_app/Gemfile.lock
@@ -1,11 +1,7 @@
 PATH
   remote: ../..
   specs:
-<<<<<<< Updated upstream
-    openapi_first (2.1.0)
-=======
     openapi_first (2.1.1)
->>>>>>> Stashed changes
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       multi_json (~> 1.15)


### PR DESCRIPTION
This was broken by https://github.com/ahx/openapi_first/commit/aa939816587a41c00400dab5e3dc5ad598370d95#diff-e7822f54d22e4b659b3f63eeabb58906298add50d0ac680c5411f95c0261dc56