### PR TITLE
Add distinct body parsers

### DIFF
--- a/lib/openapi_first/request_parser.rb
+++ b/lib/openapi_first/request_parser.rb
@@ -17,7 +17,7 @@ module OpenapiFirst
       @path_parser = OpenapiParameters::Path.new(path_parameters) if path_parameters
       @headers_parser = OpenapiParameters::Header.new(header_parameters) if header_parameters
       @cookies_parser = OpenapiParameters::Cookie.new(cookie_parameters) if cookie_parameters
-      @body_parser = BodyParser.new(content_type) if content_type
+      @body_parser = BodyParser[content_type] if content_type
     end
 
     attr_reader :query, :path, :headers, :cookies
@@ -28,7 +28,7 @@ module OpenapiFirst
       result[:query] = @query_parser.unpack(request.env[Rack::QUERY_STRING]) if @query_parser
       result[:headers] = @headers_parser.unpack_env(request.env) if @headers_parser
       result[:cookies] = @cookies_parser.unpack(request.env[Rack::HTTP_COOKIE]) if @cookies_parser
-      result[:body] = @body_parser.parse(request) if @body_parser
+      result[:body] = @body_parser.call(request) if @body_parser
       result
     end
   end

--- a/lib/openapi_first/schema.rb
+++ b/lib/openapi_first/schema.rb
@@ -20,25 +20,12 @@ module OpenapiFirst
         meta_schema: SCHEMAS.fetch(openapi_version),
         insert_property_defaults: true,
         output_format: 'classic',
-        before_property_validation: method(:before_property_validation),
         after_property_validation:
       )
     end
 
     def validate(data)
       ValidationResult.new(@schemer.validate(data))
-    end
-
-    private
-
-    def before_property_validation(data, property, property_schema, parent)
-      binary_format(data, property, property_schema, parent)
-    end
-
-    def binary_format(data, property, property_schema, _parent)
-      return unless property_schema.is_a?(Hash) && property_schema['format'] == 'binary'
-
-      data[property] = data.dig(property, :tempfile)&.read if data[property]
     end
   end
 end

--- a/spec/body_parser_spec.rb
+++ b/spec/body_parser_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::BodyParser do
+  include Rack::Test::Methods
+
+  def app = ->(_env) { Rack::Response.new.finish }
+
+  context 'with application/json' do
+    subject(:parser) { described_class['application/json'] }
+
+    it 'parses JSON' do
+      post '/', json_dump({ foo: 'bar' })
+
+      body = parser.call(last_request)
+      expect(body['foo']).to eq('bar')
+    end
+  end
+
+  context 'with multipart/form-data' do
+    subject(:parser) { described_class['multipart/form-data'] }
+
+    it 'parses form-data' do
+      uploaded_file = Rack::Test::UploadedFile.new('./spec/data/foo.txt')
+      post '/', 'file' => uploaded_file
+
+      body = parser.call(last_request)
+      expect(body['file']).to eq(File.read('./spec/data/foo.txt'))
+    end
+  end
+
+  context 'with application/x-www-form-urlencoded' do
+    subject(:parser) { described_class['application/x-www-form-urlencoded'] }
+
+    it 'parses form-data' do
+      post '/', 'foo' => 'bar'
+
+      body = parser.call(last_request)
+      expect(body['foo']).to eq('bar')
+    end
+  end
+
+  context 'with unknown/content-type' do
+    subject(:parser) { described_class['unknown/content-type'] }
+
+    it 'returns the raw body' do
+      request = Rack::Request.new('CONTENT_TYPE' => 'unknown/content-type', 'rack.input' => StringIO.new('foo,bar'))
+      body = parser.call(request)
+      expect(body).to eq('foo,bar')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'bundler/setup'
 require 'openapi_first'
 require 'multi_json'
 require 'simplecov'
+require 'rack/test'
 
 SimpleCov.start do
   enable_coverage :branch


### PR DESCRIPTION
This handles multipart file uploads inside the parser, which makes using the before-property validation hook obsolete

