### PR TITLE
Support discriminator for request bodies

### DIFF
--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -20,7 +20,12 @@ module OpenapiFirst
       ref_resolver = JSONSchemer::CachedResolver.new do |uri|
         Refs.load_file(File.join(File.dirname(filepath), uri.path))
       end
-      @doc = JSONSchemer.openapi(resolved, ref_resolver:)
+      configuration = JSONSchemer::Configuration.new(
+        ref_resolver:,
+        insert_property_defaults: true,
+        after_property_validation: config.hooks[:after_request_body_property_validation]
+      )
+      @doc = JSONSchemer.openapi(resolved, configuration:)
       @config = config
       @openapi_version = (resolved['openapi'] || resolved['swagger'])[0..2]
     end
@@ -32,7 +37,8 @@ module OpenapiFirst
       resolved['paths'].each do |path, path_item_object|
         path_item_object.slice(*REQUEST_METHODS).keys.map do |request_method|
           operation_object = path_item_object[request_method]
-          build_requests(path, request_method, operation_object, path_item_object).each do |request|
+          operation_pointer = JsonPointer.append('#', 'paths', URI::DEFAULT_PARSER.escape(path), request_method)
+          build_requests(path:, request_method:, operation_object:, operation_pointer:, path_item_object:).each do |request|
             router.add_request(
               request,
               request_method:,
@@ -40,7 +46,6 @@ module OpenapiFirst
               content_type: request.content_type
             )
           end
-          operation_pointer = JsonPointer.append('#', 'paths', URI::DEFAULT_PARSER.escape(path), request_method)
           build_responses(operation_pointer:, operation_object:).each do |response|
             router.add_response(
               response,
@@ -55,14 +60,15 @@ module OpenapiFirst
       router
     end
 
-    def build_requests(path, request_method, operation_object, path_item_object)
+    def build_requests(path:, request_method:, operation_object:, operation_pointer:, path_item_object:)
       hooks = config.hooks
       path_item_parameters = path_item_object['parameters']
       parameters = operation_object['parameters'].to_a.chain(path_item_parameters.to_a)
       required_body = operation_object.dig('requestBody', 'required') == true
       result = operation_object.dig('requestBody', 'content')&.map do |content_type, content|
+        content_schema = @doc.ref(JsonPointer.append(operation_pointer, 'requestBody', 'content', content_type, 'schema'))
         Request.new(path:, request_method:, operation_object:, parameters:, content_type:,
-                    content_schema: content['schema'], required_body:, hooks:, openapi_version:)
+                    content_schema:, required_body:, hooks:, openapi_version:)
       end || []
       return result if required_body
 

--- a/lib/openapi_first/validators/request_body.rb
+++ b/lib/openapi_first/validators/request_body.rb
@@ -7,10 +7,7 @@ module OpenapiFirst
         schema = request_definition.content_schema
         return unless schema
 
-        after_property_validation = hooks[:after_request_body_property_validation]
-
-        new(Schema.new(schema, after_property_validation:, openapi_version:),
-            required: request_definition.required_request_body?)
+        new(schema, required: request_definition.required_request_body?)
       end
 
       def initialize(schema, required:)
@@ -25,7 +22,9 @@ module OpenapiFirst
           return
         end
 
-        validation = @schema.validate(request_body)
+        validation = Schema::ValidationResult.new(
+          @schema.validate(request_body, access_mode: 'write')
+        )
         Failure.fail!(:invalid_body, errors: validation.errors) if validation.error?
       end
 

--- a/spec/data/discriminator-refs.yaml
+++ b/spec/data/discriminator-refs.yaml
@@ -21,6 +21,25 @@ paths:
                     propertyName: petType
                 type: array
   "/pets-file":
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              items:
+                oneOf:
+                  - "$ref": "./components/schemas/cat.yaml"
+                  - "$ref": "./components/schemas/dog.yaml"
+                discriminator:
+                  propertyName: petType
+                  mapping:
+                    cat: "./components/schemas/cat.yaml"
+                    dog: "./components/schemas/dog.yaml"
+              type: array
+      responses:
+        "201":
+          description: successful
     get:
       summary: Pets
       responses:

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Hooks' do
                 }
               }
             ],
-            'get' => {
+            'post' => {
               'parameters' => [
                 {
                   'name' => 'page',
@@ -102,6 +102,20 @@ RSpec.describe 'Hooks' do
                   }
                 }
               ],
+              'requestBody' => {
+                'content' => {
+                  'application/json' => {
+                    'schema' => {
+                      'type' => 'object',
+                      'properties' => {
+                        'name' => {
+                          'type' => 'string'
+                        }
+                      }
+                    }
+                  }
+                }
+              },
               'responses' => {
                 '200' => {
                   'description' => 'ok'
@@ -120,7 +134,7 @@ RSpec.describe 'Hooks' do
         end
       end
 
-      definition.validate_request(build_request('/blue?page=2'))
+      definition.validate_request(build_request('/blue?page=2', method: 'POST', body: '{"name": "Quentin"}'))
 
       expect(called).to eq([
                              [{ 'color' => 'blue' }, 'color', {
@@ -138,7 +152,7 @@ RSpec.describe 'Hooks' do
           data[property] = 'two' if property == 'page'
         end
       end
-      validated = definition.validate_request(build_request('/blue?page=2'))
+      validated = definition.validate_request(build_request('/blue?page=2', method: 'POST', body: '{"name": "Quentin"}'))
       expect(validated.parsed_query['page']).to eq('two')
       expect(validated).to be_valid
     end


### PR DESCRIPTION
This loads the referenced schema for request bodies from the main OpenAPI document instead of creating a new Schema instance. 
