### PR TITLE
2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.2.0
+
 - Fix support for discriminator in response bodies if no mapping is defined (https://github.com/ahx/openapi_first/issues/285)
 - Fix support for discriminator in request bodies if no mapping is defined
 - Replace bundled json_refs fork with own code

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (2.1.1)
+    openapi_first (2.2.0)
       hana (~> 1.3)
       json (>= 2.8.0)
       json_schemer (>= 2.1, < 3.0)

--- a/Gemfile.rack2.lock
+++ b/Gemfile.rack2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (2.1.1)
+    openapi_first (2.2.0)
       hana (~> 1.3)
       json (>= 2.8.0)
       json_schemer (>= 2.1, < 3.0)

--- a/Gemfile.rack30.lock
+++ b/Gemfile.rack30.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (2.1.1)
+    openapi_first (2.2.0)
       hana (~> 1.3)
       json (>= 2.8.0)
       json_schemer (>= 2.1, < 3.0)

--- a/Gemfile.rails6.lock
+++ b/Gemfile.rails6.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (2.1.1)
+    openapi_first (2.2.0)
       hana (~> 1.3)
       json (>= 2.8.0)
       json_schemer (>= 2.1, < 3.0)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (2.1.1)
+    openapi_first (2.2.0)
       hana (~> 1.3)
       json (>= 2.8.0)
       json_schemer (>= 2.1, < 3.0)

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.2.0'
 
-  spec.add_dependency 'json', '>= 2.8.0'
   spec.add_dependency 'hana', '~> 1.3'
+  spec.add_dependency 'json', '>= 2.8.0'
   spec.add_dependency 'json_schemer', '>= 2.1', '< 3.0'
   spec.add_dependency 'openapi_parameters', '>= 0.3.3', '< 2.0'
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'


### PR DESCRIPTION
- Fix support for discriminator in response bodies if no mapping is defined (https://github.com/ahx/openapi_first/issues/285)
- Fix support for discriminator in request bodies if no mapping is defined
- Replace bundled json_refs fork with own code
- Better error messages when OpenAPI file has invalid references ("$ref")
- Autoload OpenapiFirst::Test module. There is no need to `require 'openapi_first/test'` anymore.
- Use default json gem instead of multi_json