### PR TITLE
Fix refs with relative paths pointing outside current dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix issue with $ref resolving paths poiting outside directories `$ref: '../a/b.yaml'`
+
 ## 2.2.0
 
 - Fix support for discriminator in response bodies if no mapping is defined (https://github.com/ahx/openapi_first/issues/285)

--- a/lib/openapi_first/ref_resolver.rb
+++ b/lib/openapi_first/ref_resolver.rb
@@ -40,7 +40,7 @@ module OpenapiFirst
       def initialize(value, context: value, dir: nil)
         @value = value
         @context = context
-        @dir = dir
+        @dir = (dir && File.absolute_path(dir)) || Dir.pwd
       end
 
       # The value of this node
@@ -108,10 +108,11 @@ module OpenapiFirst
 
       def schema(options = {})
         ref_resolver = JSONSchemer::CachedResolver.new do |uri|
-          FileLoader.load(File.join(dir, uri.path))
+          FileLoader.load(uri.path)
         end
-        root = JSONSchemer::Schema.new(context, ref_resolver:, **options)
-        JSONSchemer::Schema.new(value, nil, root, **options)
+        base_uri = URI::File.build({ path: "#{dir}/" })
+        root = JSONSchemer::Schema.new(context, base_uri:, ref_resolver:, **options)
+        JSONSchemer::Schema.new(value, nil, root, base_uri:, **options)
       end
     end
 

--- a/spec/ref_resolver_spec.rb
+++ b/spec/ref_resolver_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe OpenapiFirst::RefResolver do
       expect(schema.valid?([{ id: 2, name: 'Spet' }])).to eq(true)
       expect(schema.valid?([{ id: 'two', name: 'Spet' }])).to eq(false)
     end
+
+    it 'works with relative paths in the schema' do
+      node = described_class.load('./spec/data/splitted-train-travel-api/openapi.yaml')
+      schema = node.dig('paths', '/bookings', 'get', 'responses', '200', 'content', 'application/json', 'schema').schema
+      expect(schema.valid?({ data: [{ has_bicycle: true }] })).to eq(true)
+      expect(schema.valid?({ data: [{ has_bicycle: 'red' }] })).to eq(false)
+    end
   end
 
   describe '#[]' do


### PR DESCRIPTION
This fixes resolving refs like '../a/b.json'.

The main issue here was that `URI.join(base_uri, other)`, which is called inside json_schemer, needs a path ending with a slash otherwise it does not treat the dirname as a path fragment.

Related to https://github.com/ahx/openapi_first/issues/313
