### PR TITLE
Add support for custom JSONSchemer configuration

### DIFF
--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -18,10 +18,10 @@ module OpenapiFirst
     end
 
     def initialize(contents, filepath:, config:)
-      @schemer_configuration = JSONSchemer::Configuration.new(
-        meta_schema: detect_meta_schema(contents, filepath),
-        insert_property_defaults: true
-      )
+      @schemer_configuration = JSONSchemer.configuration.clone
+      @schemer_configuration.meta_schema = detect_meta_schema(contents, filepath)
+      @schemer_configuration.insert_property_defaults = true
+
       @config = config
       @contents = RefResolver.for(contents, dir: filepath && File.dirname(filepath))
     end


### PR DESCRIPTION
A small change to make it so that the global `JSONSchemer.configuration` is respected when `openapi_first` builds its router. I made it so that `openapi_first` will first `clone` the configuration before making the changes it needs to so that it avoids adjusting the global configuration in case something else in a dev's project is using it.

This useful for something like supporting custom `format`s. For example, I can now do something like

```ruby
JSONSchemer.configure do |config|
  config.formats = { 'uuid' => ->(instance, format) { Utils.is_uuid?(instance) } }
end

OpenapiFirst.load('openapi.yaml')
```

and `openapi_first` will pick up that configuration and apply it to the `JSONSchemer.schema`s it creates as it builds the router, which allows it to work with my custom format.

Prior to version 2.2, this would work. Recent changes made it so that a new `JSONSchemer::Configuration` instance was created, so any prior changes made to `JSONSchemer.configuration` would no longer be applied.