### PR TITLE
Make schema available on validation errors

### DIFF
--- a/lib/openapi_first/schema/validation_error.rb
+++ b/lib/openapi_first/schema/validation_error.rb
@@ -3,7 +3,7 @@
 module OpenapiFirst
   class Schema
     # One of multiple validation errors. Returned by Schema::ValidationResult#errors.
-    ValidationError = Data.define(:message, :data_pointer, :schema_pointer, :type, :details) do
+    ValidationError = Data.define(:message, :data_pointer, :schema_pointer, :type, :details, :schema) do
       # @deprecated Please use {#message} instead
       def error
         warn 'OpenapiFirst::Schema::ValidationError#error is deprecated. Use #message instead.'

--- a/lib/openapi_first/schema/validation_result.rb
+++ b/lib/openapi_first/schema/validation_result.rb
@@ -20,7 +20,8 @@ module OpenapiFirst
             data_pointer: err['data_pointer'],
             schema_pointer: err['schema_pointer'],
             type: err['type'],
-            details: err['details']
+            details: err['details'],
+            schema: err['schema']
           )
         end
       end


### PR DESCRIPTION
A small change to make the `schema` available on the `ValidationError`s included in the `ValidationResult`.

The intent here is to give the API more flexibility around what error messages it surfaces to the client. For example, an error from `json_schemer` will provide a `"type" => "discriminator"` and ` "error" => "value at root does not match `discriminator` schema"`, and it would be helpful to be able to inspect the schema to include the `propertyName` and/or acceptable `mapping`s.

The error caught by `json_schemer` includes both `schema` and `parent` in addition to the other keys that are already included. This simply updates the `ValidationError` struct to also accept the `schema`. 