### PR TITLE
Provide root context for json pointer resolution

### DIFF
--- a/lib/openapi_first/ref_resolver.rb
+++ b/lib/openapi_first/ref_resolver.rb
@@ -55,7 +55,7 @@ module OpenapiFirst
           value = Hana::Pointer.new(pointer[1..]).eval(context)
           raise "Unknown reference #{pointer} in #{context}" unless value
 
-          return RefResolver.for(value, dir:)
+          return RefResolver.for(value, dir:, context:)
         end
 
         relative_path, file_pointer = pointer.split('#')
@@ -65,7 +65,7 @@ module OpenapiFirst
         file_contents = FileLoader.load(full_path)
         new_dir = File.dirname(full_path)
         value = Hana::Pointer.new(file_pointer).eval(file_contents)
-        RefResolver.for(value, dir: new_dir)
+        RefResolver.for(value, dir: new_dir, context: file_contents)
       end
     end
 

--- a/spec/data/petstore-openapi-object-references.yaml
+++ b/spec/data/petstore-openapi-object-references.yaml
@@ -1,0 +1,70 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          $ref: '#/components/responses/Pets'
+        default:
+          $ref: '#/components/responses/default'
+components:
+  responses:
+    default: 
+      description: unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Pets:
+      description: A paged array of pets
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pets"
+  schemas:
+    Pets:
+      type: array
+      title: Pets
+      items:
+        $ref: "#/components/schemas/Pet"
+    Pet:
+        required:
+          - id
+          - name
+        properties:
+          id:
+            type: integer
+            format: int64
+          name:
+            type: string
+          tag:
+            type: string
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/spec/data/petstore.yaml
+++ b/spec/data/petstore.yaml
@@ -7,15 +7,6 @@ info:
 servers:
   - url: http://petstore.swagger.io/v1
 paths:
-  /dogs:
-    get:
-      summary: List all dogs
-      operationId: listDogs
-      tags:
-        - dogs
-      responses:
-        '200':
-          $ref: '#/components/responses/Dogs'
   /pets:
     get:
       summary: List all pets
@@ -83,32 +74,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pets"
 components:
-  responses:
-    Dogs:
-      description: A paged array of dogs
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Dogs"
-
   schemas:
-    Dogs:
-      type: array
-      title: Dogs
-      items:
-        $ref: "#/components/schemas/Dog"
-    Dog:
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: integer
-          format: int64
-        name:
-          type: string
-        bark:
-          type: string
     Pets:
       type: array
       title: Pets

--- a/spec/data/petstore.yaml
+++ b/spec/data/petstore.yaml
@@ -7,6 +7,15 @@ info:
 servers:
   - url: http://petstore.swagger.io/v1
 paths:
+  /dogs:
+    get:
+      summary: List all dogs
+      operationId: listDogs
+      tags:
+        - dogs
+      responses:
+        '200':
+          $ref: '#/components/responses/Dogs'
   /pets:
     get:
       summary: List all pets
@@ -74,7 +83,32 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pets"
 components:
+  responses:
+    Dogs:
+      description: A paged array of dogs
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Dogs"
+
   schemas:
+    Dogs:
+      type: array
+      title: Dogs
+      items:
+        $ref: "#/components/schemas/Dog"
+    Dog:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        bark:
+          type: string
     Pets:
       type: array
       title: Pets

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
     end
   end
 
-  context 'with an unkown route' do
+  context 'with an unknown route' do
     it 'skips response validation' do
       get '/unknown'
       expect(last_response.status).to eq 200
@@ -402,6 +402,19 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
       expect do
         post '/echo', JSON.generate({ 'X-Id' => '42' })
       end.to raise_error OpenapiFirst::ResponseInvalidError
+    end
+  end
+
+  describe 'with Response Object references' do
+    context 'when response is valid' do
+      let(:response_body) { JSON.generate([{ id: 42, name: 'Hank', bark: 'Woof' }]) }
+
+      it 'returns no errors' do
+        get '/dogs'
+
+        expect(last_response.status).to eq 200
+        expect(last_response.body).to eq response_body
+      end
     end
   end
 end

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -398,15 +398,49 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
   end
 
   describe 'with Response Object references' do
-    context 'when response is valid' do
-      let(:spec) { 'spec/data/petstore-openapi-object-references.yaml' }
+    let(:spec) { 'spec/data/petstore-openapi-object-references.yaml' }
+
+    context 'when response is a valid 200' do
       let(:response_body) { JSON.generate([{ id: 42, name: 'Hank' }]) }
 
-      it 'returns no errors' do
-        get '/dogs'
+      it 'returns no errors ' do
+        get '/pets'
 
         expect(last_response.status).to eq 200
         expect(last_response.body).to eq response_body
+      end
+    end
+
+    context 'when response is a valid default' do
+      let(:status) { 404 }
+      let(:response_body) { JSON.generate({ code: 123, message: 'Boom!' }) }
+
+      it 'returns no errors' do
+        get '/pets'
+
+        expect(last_response.status).to eq 404
+        expect(last_response.body).to eq response_body
+      end
+    end
+
+    context 'when response is an invalid 200' do
+      let(:response_body) { JSON.generate({ id: 42, name: 'Hank' }) }
+
+      it 'raises an error' do
+        expect do
+          get '/pets'
+        end.to raise_error OpenapiFirst::ResponseInvalidError, 'Response body is invalid: value at root is not an array'
+      end
+    end
+
+    context 'when response is an invalid default' do
+      let(:status) { 404 }
+      let(:response_body) { JSON.generate({ code: 123, message: 123 }) }
+
+      it 'raises an error' do
+        expect do
+          get '/pets'
+        end.to raise_error OpenapiFirst::ResponseInvalidError, 'Response body is invalid: value at `/message` is not a string'
       end
     end
   end

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -25,15 +25,6 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
   end
   let(:response) { Rack::Response.new(response_body, status, headers) }
 
-  context 'with a valid response' do
-    it 'returns no errors' do
-      get '/pets'
-
-      expect(last_response.status).to eq 200
-      expect(last_response.body).to eq response_body
-    end
-  end
-
   context 'without content-type header' do
     let(:headers) do
       { 'X-HEAD' => '/api/next-page' }
@@ -237,6 +228,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
       get '/pets'
 
       expect(last_response.status).to eq 200
+      expect(last_response.body).to eq response_body
     end
   end
 
@@ -407,7 +399,8 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
 
   describe 'with Response Object references' do
     context 'when response is valid' do
-      let(:response_body) { JSON.generate([{ id: 42, name: 'Hank', bark: 'Woof' }]) }
+      let(:spec) { 'spec/data/petstore-openapi-object-references.yaml' }
+      let(:response_body) { JSON.generate([{ id: 42, name: 'Hank' }]) }
 
       it 'returns no errors' do
         get '/dogs'

--- a/spec/ref_resolver_spec.rb
+++ b/spec/ref_resolver_spec.rb
@@ -38,11 +38,32 @@ RSpec.describe OpenapiFirst::RefResolver do
   end
 
   describe '#context' do
-    it 'returns the parent object' do
+    it 'returns contents of the main file' do
       file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
       doc = described_class.load(file_path)
-      node = doc['paths']['/stations']['get']['responses']['200']
+      node = doc['info']
+      expect(node.context['openapi']).to eq('3.1.0')
+    end
+
+    it 'returns contents of the main file when following internal refs' do
+      file_path = './spec/data/train-travel-api/openapi.yaml'
+      doc = described_class.load(file_path)
+      node = doc['paths']['/stations']['get']['responses']['200']['headers']['RateLimit']['schema']
+      expect(node.context['openapi']).to eq('3.1.0')
+    end
+
+    it 'returns contents of the referenced file' do
+      file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
+      doc = described_class.load(file_path)
+      node = doc['paths']['/stations']['get']['responses']
       expect(node.context.dig('get', 'description')).to start_with('Returns a list of all train stations')
+    end
+
+    it 'returns contents of the referenced file when pointing inside referenced files' do
+      file_path = './spec/data/petstore.yaml'
+      doc = described_class.load(file_path)
+      node = doc['components']['schemas']['Pet']['required']
+      expect(node.context).to eq(YAML.load_file('./spec/data/components/schemas/pet.yaml'))
     end
   end
 


### PR DESCRIPTION
Before getting started, I want to preface with: I don't know if my assessment of the problem is correct, so please scrutinize. I'm still learning how the newer reference resolver strategy works, so I'm uncertain if what I'm proposing here has tradeoffs or consequences I am unaware of.

Given a simple Openapi definition like the following:

```yaml
openapi: 3.1.0
paths:
  /foo:
    get:
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Foos'
         '400':
         	$ref: '#/components/responses/400'
components:
  responses:
    '400':
      description: Forbidden
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/Errors'
  schemas:
    Foos:
      type: object
      properties:
        foos:
        type: array
        items:
          $ref: '#/components/schemas/Foo'
    Foo:
      type: object
    Errors:
      type: object
      properties:
        errors:
          type: array
          items:
            type: object
```

The things to note here:
- All schemas are under `components`, so the `ref_resolver` that does the file loading doesn't run
- The 200 response is an inline Response Object, with a `$ref` to a [Schema Object](https://spec.openapis.org/oas/v3.1.0#schema-object)
- The 400 response is `$ref` to a [Response Object](https://spec.openapis.org/oas/v3.1.0#responses-object), which contains a `$ref` to a [Schema Object](https://spec.openapis.org/oas/v3.1.0#schema-object)

When calling `/foo`, response validation works for a 200 response. It's able to resolve all `$refs` in the Response Object! Awesome!

However, response validation will raise an error for the 400 response.
> JSONSchemer::InvalidRefPointer: /components/schemas/Errors

If I move the Response Object to be inline - similar to how the 200 looks - it works.

I did my best to debug the code to see what the difference was. What I noticed is that when the schema was being created from the `Hash` resolver for the 200, the `context` was the root Openapi definition. When it was creating it for the `400` response, the `context` as the Response Object schema. 

From what I gather, when `json_schema` encounters a `$ref` that is a json pointer, it will attempt to find the component in the root context. For the 200, it was there, but for the 400, it was not.

I noticed that the root `RefResolver`'s `context` will be the Openapi `contents` because `context` defaults to the provided `value`. This context gets passed around in `RefResolver.for`, and the `Hash` and `Array` resolvers... but seems to be missing in the base `resolve_ref`, which causes the `context` to be "reset" to the current schema.

This PR updates the `resolve_ref` method so that the Openapi content propagates through to `RefResolver.for` to ensure the the `JSONSchemer` schemas have the `root` set to the Openapi contents, making the `components` available.

I can follow up and add tests to reproduce the error and validate the change, but I first wanted to get your thoughts on this to make sure I'm on the right track; I'm not sure if this change has other consequences.