### PR TITLE
Add Coverage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,4 +30,6 @@ Layout/LineLength:
   Exclude:
     - "spec/**/*.rb"
 Metrics/MethodLength:
+  Exclude:
+    - "lib/openapi_first/test/coverage/*_formatter.rb"
   Max: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### New feature
+- Add OpenapiFirst::Test::Coverage to track request/response coverage for your API descriptions. (https://github.com/ahx/openapi_first/pull/327)
+
 ## 2.2.4
 
 - Fix request validation file uploads in multipart/form-data requests with nested fields (https://github.com/ahx/openapi_first/issues/324)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ Here is how to set it up:
   ```ruby
   Minitest.after_run do
     OpenapiFirst::Test.report_coverage # Prints a coverage report to the terminal
-    OpenapiFirst::Test.result.coverage # Returns the overal coverage in percent
   end
   ```
 

--- a/README.md
+++ b/README.md
@@ -139,25 +139,27 @@ use OpenapiFirst::Middlewares::ResponseValidation, raise_error: true, spec: 'ope
 This feature tracks all requests/resposes that are validated via openapi_first and get return an overal coverage value. If all of your described requests/responses have been validated successfully at least once, your coverage is 100%.
 By checking your validation coverage you can avoid API drift where your API description describes requests/responses differently than your implemention works.
 
-Here is how to set it up:
+Here is how to set it up for RSpec in your `spec/spec_helper.rb`:
 
 1. Register all OpenAPI documents to track coverage for and start tracking. This should go at the top of you test helper file before loading application code.
   ```ruby
+  require 'openapi_first'
   OpenapiFirst::Test.setup do |test|
     test.register('openapi/openapi.yaml')
   end
   ```
 2. Wrap your app with silent request / response validation. This validates all requets/responses you do during your test run. (✷1)
   ```ruby
-  def app
-    OpenapiFirst::Test.app(MyRackApp)
+  config.before type: :request do
+    def app
+      OpenapiFirst::Test::(App)
+    end
   end
   ```
 3. Check coverage after your test suite has finished
   ```ruby
-  Minitest.after_run do
-    OpenapiFirst::Test.report_coverage # Prints a coverage report to the terminal
-  end
+  # Prints a coverage report to the terminal
+  config.after(:suite) { OpenapiFirst::Test.report_coverage }
   ```
 
 (✷1): Instead of using `OpenapiFirstTest.app` to wrap your application, you can use the middlewares or [test assertion method](#test-assertions), but you would have to do that for all requests/responses defined in your API description to make coverage work.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ use OpenapiFirst::Middlewares::ResponseValidation, raise_error: true, spec: 'ope
 
 ### Coverage
 
+> [!NOTE]
+> This is a brand new feature. ✨ Your feedback is very welcome.
+
 This feature tracks all requests/resposes that are validated via openapi_first and get return an overal coverage value. If all of your described requests/responses have been validated successfully at least once, your coverage is 100%.
 By checking your validation coverage you can avoid API drift where your API description describes requests/responses differently than your implemention works.
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # openapi_first
 
-OpenapiFirst helps to implement HTTP APIs based on an [OpenAPI](https://www.openapis.org/) API description. It supports OpenAPI 3.0 and 3.1. It offers request and response validation and it ensures that your implementation follows exactly the API description.
+openapi_first is a Ruby gem for request / response validation and contract-testing against an [OpenAPI](https://www.openapis.org/) 3.0 or 3.1 API description. It makes an APIFirst workflow easy and reliable.
 
-[![Tests](https://github.com/ahx/openapi_first/actions/workflows/ruby.yml/badge.svg)](https://github.com/ahx/openapi_first/actions/workflows/ruby.yml)
-[![CodeQL](https://github.com/ahx/openapi_first/actions/workflows/codeql.yml/badge.svg)](https://github.com/ahx/openapi_first/blob/codeql/.github/workflows/codeql.yml)
+You can use openapi_first on production for [request validation](#request-validation) and in your tests to avoid API drift with it's request/response validation and coverage features.
 
 ## Contents
 
 <!-- TOC -->
 
-- [Manual use](#manual-use)
-  - [Validate request](#validate-request)
-  - [Validate response](#validate-response)
 - [Rack Middlewares](#rack-middlewares)
   - [Request validation](#request-validation)
   - [Response validation](#response-validation)
 - [Contract testing](#contract-testing)
+  - [Coverage](#coverage)
   - [Test assertions](#test-assertions)
+- [Manual use](#manual-use)
 - [Framework integration](#framework-integration)
 - [Configuration](#configuration)
 - [Hooks](#hooks)
@@ -26,6 +24,169 @@ OpenapiFirst helps to implement HTTP APIs based on an [OpenAPI](https://www.open
   - [Contributing](#contributing)
 
 <!-- /TOC -->
+
+## Rack Middlewares
+
+### Request validation
+
+The request validation middleware returns a 4xx if the request is invalid or not defined in the API description. It adds a request object to the current Rack environment at `env[OpenapiFirst::REQUEST]` with the request parameters parsed exaclty as described in your API description plus access to meta information from your API description. See _[Manual use](#manual-use)_ for more details about that object.
+
+```ruby
+use OpenapiFirst::Middlewares::RequestValidation, spec: 'openapi.yaml'
+
+# Pass `raise_error: true` to raise an error if request is invalid:
+use OpenapiFirst::Middlewares::RequestValidation, raise_error: true, spec: 'openapi.yaml'
+```
+
+#### Error responses
+
+openapi_first produces a useful machine readable error response that can be customized.
+The default response looks like this. See also [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457).
+
+```json
+http-status: 400
+content-type: "application/problem+json"
+
+{
+  "title": "Bad Request Body",
+  "status": 400,
+  "errors": [
+    {
+      "message": "value at `/data/name` is not a string",
+      "pointer": "/data/name",
+      "code": "string"
+    },
+    {
+      "message": "number at `/data/numberOfLegs` is less than: 2",
+      "pointer": "/data/numberOfLegs",
+      "code": "minimum"
+    },
+    {
+      "message": "object at `/data` is missing required properties: mandatory",
+      "pointer": "/data",
+      "code": "required"
+    }
+  ]
+}
+```
+
+openapi_first offers a [JSON:API](https://jsonapi.org/) error response by passing `error_response: :jsonapi`:
+
+```ruby
+use OpenapiFirst::Middlewares::RequestValidation, spec: 'openapi.yaml, error_response: :jsonapi'
+```
+
+<details>
+<summary>See details of JSON:API error response</summary>
+
+```json
+// http-status: 400
+// content-type: "application/vnd.api+json"
+
+{
+  "errors": [
+    {
+      "status": "400",
+      "source": {
+        "pointer": "/data/name"
+      },
+      "title": "value at `/data/name` is not a string",
+      "code": "string"
+    },
+    {
+      "status": "400",
+      "source": {
+        "pointer": "/data/numberOfLegs"
+      },
+      "title": "number at `/data/numberOfLegs` is less than: 2",
+      "code": "minimum"
+    },
+    {
+      "status": "400",
+      "source": {
+        "pointer": "/data"
+      },
+      "title": "object at `/data` is missing required properties: mandatory",
+      "code": "required"
+    }
+  ]
+}
+```
+
+</details>
+
+#### Custom error responses
+
+You can build your own custom error response with `error_response: MyCustomClass` that implements `OpenapiFirst::ErrorResponse`.
+You can define custom error responses globally by including / implementing `OpenapiFirst::ErrorResponse` and register it via `OpenapiFirst.register_error_response(my_name, MyCustomErrorResponse)` and set `error_response: my_name`.
+
+### Response validation
+
+This middleware raises an error by default if the response is not valid.
+This can be useful in a test or staging environment, especially if you are adopting OpenAPI for an existing implementation.
+
+```ruby
+use OpenapiFirst::Middlewares::ResponseValidation, spec: 'openapi.yaml' if ENV['RACK_ENV'] == 'test'
+
+# Pass `raise_error: false` to not raise an error:
+use OpenapiFirst::Middlewares::ResponseValidation, raise_error: true, spec: 'openapi.yaml'
+```
+
+## Contract Testing
+
+### Coverage
+
+This feature tracks all requests/resposes that are validated via openapi_first and get return an overal coverage value. If all of your described requests/responses have been validated successfully at least once, your coverage is 100%.
+By checking your validation coverage you can avoid API drift where your API description describes requests/responses differently than your implemention works.
+
+Here is how to set it up:
+
+1. Register all OpenAPI documents to track coverage for and start tracking. This should go at the top of you test helper file before loading application code.
+  ```ruby
+  OpenapiFirst::Test.setup do |test|
+    test.register('openapi/openapi.yaml')
+  end
+  ```
+2. Wrap your app with silent request / response validation. This validates all requets/responses you do during your test run. (✷1)
+  ```ruby
+  def app
+    OpenapiFirst::Test.app(MyRackApp)
+  end
+  ```
+3. Check coverage after your test suite has finished
+  ```ruby
+  Minitest.after_run do
+    OpenapiFirst::Test.report_coverage # Prints a coverage report to the terminal
+    OpenapiFirst::Test.result.coverage # Returns the overal coverage in percent
+  end
+  ```
+
+(✷1): Instead of using `OpenapiFirstTest.app` to wrap your application, you can use the middlewares or [test assertion method](#test-assertions), but you would have to do that for all requests/responses defined in your API description to make coverage work.
+
+### Test assertions
+
+openapi_first ships with a simple but powerful Test method to run request and response validation in your tests without using the middlewares. This is designed to be used with rack-test or Ruby on Rails integration tests or request specs.
+
+Here is how to set it up for Rails integration tests:
+
+Inside your test:
+```ruby
+# test/integration/trips_api_test.rb
+require 'test_helper'
+
+class TripsApiTest < ActionDispatch::IntegrationTest
+  include OpenapiFirst::Test::Methods
+
+  test 'GET /trips' do
+    get '/trips',
+        params: { origin: 'efdbb9d1-02c2-4bc3-afb7-6788d8782b1e', destination: 'b2e783e1-c824-4d63-b37a-d8d698862f1d',
+                  date: '2024-07-02T09:00:00Z' }
+
+    assert_api_conform(status: 200)
+    # assert_api_conform(status: 200, api: :v1) # Or this if you have multiple API descriptions
+  end
+end
+```
 
 ## Manual use
 
@@ -78,186 +239,6 @@ validated_response.parsed_headers
 
 # Or you can raise an exception if validation fails:
 definition.validate_response(rack_request,rack_response, raise_error: true) # Raises OpenapiFirst::ResponseInvalidError or OpenapiFirst::ResponseNotFoundError
-```
-
-## Rack Middlewares
-
-### Request validation
-
-The request validation middleware returns a 4xx if the request is invalid or not defined in the API description. It adds a request object to the current Rack environment at `env[OpenapiFirst::REQUEST]` with the request parameters parsed exaclty as described in your API description plus access to meta information from your API description. See _[Manual use](#manual-use)_ for more details about that object.
-
-```ruby
-use OpenapiFirst::Middlewares::RequestValidation, spec: 'openapi.yaml'
-```
-
-#### Options
-
-| Name              | Possible values                                                          | Description                                                                                                                         |
-| :---------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `spec:`           |                                                                          | The path to the spec file or spec loaded via `OpenapiFirst.load`                                                                    |
-| `raise_error:`    | `false` (default), `true`                                                | If set to true the middleware raises `OpenapiFirst::RequestInvalidError` or `OpenapiFirst::NotFoundError` instead of returning 4xx. |
-| `error_response:` | `:default` (default), `:jsonapi`, Your implementation of `ErrorResponse` or `false` to disable responding  |
-
-#### Error responses
-
-openapi_first produces a useful machine readable error response that can be customized.
-The default response looks like this. See also [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457).
-
-```json
-http-status: 400
-content-type: "application/problem+json"
-
-{
-  "title": "Bad Request Body",
-  "status": 400,
-  "errors": [
-    {
-      "message": "value at `/data/name` is not a string",
-      "pointer": "/data/name",
-      "code": "string"
-    },
-    {
-      "message": "number at `/data/numberOfLegs` is less than: 2",
-      "pointer": "/data/numberOfLegs",
-      "code": "minimum"
-    },
-    {
-      "message": "object at `/data` is missing required properties: mandatory",
-      "pointer": "/data",
-      "code": "required"
-    }
-  ]
-}
-```
-
-openapi_first offers a [JSON:API](https://jsonapi.org/) error response as well:
-
-```ruby
-use OpenapiFirst::Middlewares::RequestValidation, spec: 'openapi.yaml, error_response: :jsonapi'
-```
-
-<details>
-<summary>See details of JSON:API error response</summary>
-
-```json
-// http-status: 400
-// content-type: "application/vnd.api+json"
-
-{
-  "errors": [
-    {
-      "status": "400",
-      "source": {
-        "pointer": "/data/name"
-      },
-      "title": "value at `/data/name` is not a string",
-      "code": "string"
-    },
-    {
-      "status": "400",
-      "source": {
-        "pointer": "/data/numberOfLegs"
-      },
-      "title": "number at `/data/numberOfLegs` is less than: 2",
-      "code": "minimum"
-    },
-    {
-      "status": "400",
-      "source": {
-        "pointer": "/data"
-      },
-      "title": "object at `/data` is missing required properties: mandatory",
-      "code": "required"
-    }
-  ]
-}
-```
-
-</details>
-
-#### Custom error responses
-
-You can build your own custom error response with `error_response: MyCustomClass` that implements `OpenapiFirst::ErrorResponse`.
-You can define custom error responses globally by including / implementing `OpenapiFirst::ErrorResponse` and register it via `OpenapiFirst.register_error_response(my_name, MyCustomErrorResponse)` and set `error_response: my_name`.
-
-#### readOnly / writeOnly properties
-
-Request validation fails if request includes a property with `readOnly: true`.
-
-Response validation fails if response body includes a property with `writeOnly: true`.
-
-### Response validation
-
-This middleware is especially useful when testing. It raises an error by default if the response is not valid.
-
-```ruby
-use OpenapiFirst::Middlewares::ResponseValidation, spec: 'openapi.yaml' if ENV['RACK_ENV'] == 'test'
-```
-
-#### Options
-
-| Name    | Possible values | Description                                                      |
-| :------ | --------------- | ---------------------------------------------------------------- |
-| `spec:` |                 | The path to the spec file or spec loaded via `OpenapiFirst.load` |
-| `raise_error:`    | `true` (default), `false`                                                | If set to true the middleware raises `OpenapiFirst::ResponseInvalidError` or `OpenapiFirst::ResonseNotFoundError` if the response does not match the API description. |
-
-## Contract Testing
-
-### Test Coverage
-
-You can track which requests and responses of your API description have been called during testing!
-
-This tracks all requests and resposes that are validated via OpenapiFirst. If all of your described requests/responses have been validated successfully at least once, your coverage is 100%.
-
-Here is how to set it up:
-
-1. Register all OpenAPI documents to track coverage for and start tracking
-   Note that this should go at the top of you test helper file before loading application code.
-  ```ruby
-  OpenapiFirst::Test.setup do |test|
-    test.register('openapi/openapi.yaml')
-  )
-  ```
-
-2. Wrap your app with silent request / response validation. This validates all requets/responses you do during your test run.
-  ```ruby
-  def app
-    OpenapiFirst::Test.app(MyRackApp)
-  end
-  ```
-  Instead of doing that you can use the middlewares or test assertion method, but you would have to do that for all requests/responses defined in your API description to make coverage work.
-
-
-3. Report after your test suite has finished
-  ```ruby
-  Minitest.after_run do
-    coverage OpenapiFirst::Test.result
-  end
-  ```
-
-### Test assertions
-
-openapi_first ships with a simple but powerful Test method to run request and response validation in your tests without using the middlewares. This is designed to be used with rack-test or Ruby on Rails integration tests or request specs.
-
-Here is how to set it up for Rails integration tests:
-
-Inside your test:
-```ruby
-# test/integration/trips_api_test.rb
-require 'test_helper'
-
-class TripsApiTest < ActionDispatch::IntegrationTest
-  include OpenapiFirst::Test::Methods
-
-  test 'GET /trips' do
-    get '/trips',
-        params: { origin: 'efdbb9d1-02c2-4bc3-afb7-6788d8782b1e', destination: 'b2e783e1-c824-4d63-b37a-d8d698862f1d',
-                  date: '2024-07-02T09:00:00Z' }
-
-    assert_api_conform(status: 200)
-    # assert_api_conform(status: 200, api: :v1) # Or this if you have multiple API descriptions
-  end
-end
 ```
 
 ## Configuration
@@ -322,16 +303,6 @@ end
 Using rack middlewares is supported in probably all Ruby web frameworks.
 If you are using Ruby on Rails for example, you can add the request validation middleware globally in `config/application.rb` or inside specific controllers.
 
-When running integration tests (or request specs when using rspec), it makes sense to add the response validation middleware to `config/environments/test.rb`:
-
-```ruby
-config.middleware.use OpenapiFirst::Middlewares::ResponseValidation,
-  spec: 'api/openapi.yaml'
-```
-
-That way you don't have to call specific test assertions to make sure your API matches the OpenAPI document.
-There is no need to run response validation on production if your test coverage is decent.
-
 ## Alternatives
 
 This gem was inspired by [committe](https://github.com/interagent/committee) (Ruby) and [Connexion](https://github.com/spec-first/connexion) (Python).
@@ -359,6 +330,6 @@ bundle exec ruby benchmarks.rb
 
 ### Contributing
 
-If you have a question or an idea or found a bug don't hesitate to [create an issue](https://github.com/ahx/openapi_first/issues) or [start a discussion](https://github.com/ahx/openapi_first/discussions).
+If you have a question or an idea or found a bug, don't hesitate to create an issue [on Github](https://github.com/ahx/openapi_first) or [Codeberg](https://codeberg.org/ahx/openapi_first) or say hi on [Mastodon (ruby.social)](https://ruby.social/@ahx).
 
 Pull requests are very welcome as well, of course. Feel free to create a "draft" pull request early on, even if your change is still work in progress. 🤗

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ OpenapiFirst helps to implement HTTP APIs based on an [OpenAPI](https://www.open
 - [Rack Middlewares](#rack-middlewares)
   - [Request validation](#request-validation)
   - [Response validation](#response-validation)
+- [Test coverage](#test-coverage)
 - [Test assertions](#test-assertions)
 - [Framework integration](#framework-integration)
 - [Configuration](#configuration)
@@ -200,9 +201,42 @@ use OpenapiFirst::Middlewares::ResponseValidation, spec: 'openapi.yaml' if ENV['
 | `spec:` |                 | The path to the spec file or spec loaded via `OpenapiFirst.load` |
 | `raise_error:`    | `true` (default), `false`                                                | If set to true the middleware raises `OpenapiFirst::ResponseInvalidError` or `OpenapiFirst::ResonseNotFoundError` if the response does not match the API description. |
 
-## Test assertions
+## Testing
 
-openapi_first ships with a simple but powerful Test module to run request and response validation in your tests without using the middlewares. This is designed to be used with rack-test or Ruby on Rails integration tests or request specs.
+### Test Coverage
+
+You can track which requests and responses of your API description have been called during testing!
+
+This tracks whenever a request or respose is validated via OpenapiFirst. If all of your described requests/responses have been validated successfully at least once, your coverage is 100%.
+
+Here is how to set it up:
+
+1. Wrap your app with silent request / response validation. This validates all requets/responses you do during your test run. You can use this instead of the middlewares or test assertion method.
+  ```ruby
+  def app
+    OpenapiFirst::Test.app(MyRackApp, spec: 'openapi/openapi.yaml')
+  end
+  ```
+
+2. Register all OpenAPI documents to track coverage for and start tracking
+  ```ruby
+  OpenapiFirst::Test::Coverage.register(
+    'openapi/v1.openapi.yaml',
+    'openapi/openapi.yaml'
+  )
+
+  OpenapiFirst::Test::Coverage.start
+  ```
+3. Report after your test suite has finished
+  ```ruby
+  Minitest.after_run do
+    OpenapiFirst::Test::Coverage.report
+  end
+  ```
+
+### Test assertions
+
+openapi_first ships with a simple but powerful Test method to run request and response validation in your tests without using the middlewares. This is designed to be used with rack-test or Ruby on Rails integration tests or request specs.
 
 Here is how to set it up for Rails integration tests:
 

--- a/examples/rails_app/Gemfile.lock
+++ b/examples/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    openapi_first (2.2.1)
+    openapi_first (2.2.3)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.3.3, < 2.0)

--- a/examples/rails_app/test/test_helper.rb
+++ b/examples/rails_app/test/test_helper.rb
@@ -2,9 +2,19 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
 
-require 'openapi_first/test'
+require 'openapi_first'
 OpenapiFirst::Test.register(Rails.root.join('../../spec/data/train-travel-api/openapi.yaml'))
 OpenapiFirst::Test.register(Rails.root.join('../../spec/data/attachments_openapi.yaml'), as: :attachments)
+
+OpenapiFirst::Test::Coverage.register(
+  Rails.root.join('../../spec/data/train-travel-api/openapi.yaml'),
+  Rails.root.join('../../spec/data/attachments_openapi.yaml')
+)
+OpenapiFirst::Test::Coverage.start
+
+Minitest.after_run do
+  OpenapiFirst::Test::Coverage.report
+end
 
 module ActiveSupport
   class TestCase
@@ -12,5 +22,15 @@ module ActiveSupport
     parallelize(workers: :number_of_processors)
 
     # Add more helper methods to be used by all tests here...
+  end
+end
+
+TEST_APP = OpenapiFirst::Test.app(TrainTravel::Application, spec: Rails.root.join('../../spec/data/attachments_openapi.yaml'))
+
+module ActionDispatch
+  class IntegrationTest
+    def app
+      TEST_APP
+    end
   end
 end

--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -110,12 +110,7 @@ module OpenapiFirst
       content_objects = operation_object.dig('requestBody', 'content')
       if content_objects.nil?
         return [
-          Request.new(path:, request_method:, parameters:,
-                      operation_object: operation_object.resolved,
-                      content_type: nil,
-                      content_schema: nil,
-                      required_body: false,
-                      key: [path, request_method, nil].join(':'))
+          request_without_body(path:, request_method:, parameters:, operation_object:)
         ]
       end
       required_body = operation_object['requestBody']&.resolved&.fetch('required', false) == true
@@ -131,6 +126,15 @@ module OpenapiFirst
                     required_body:,
                     key: [path, request_method, content_type].join(':'))
       end
+    end
+
+    def request_without_body(path:, request_method:, parameters:, operation_object:)
+      Request.new(path:, request_method:, parameters:,
+                  operation_object: operation_object.resolved,
+                  content_type: nil,
+                  content_schema: nil,
+                  required_body: false,
+                  key: [path, request_method, nil].join(':'))
     end
 
     def build_responses(responses:, request:)

--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -60,15 +60,15 @@ module OpenapiFirst
               path:,
               content_type: request.content_type
             )
-          end
-          build_responses(responses: operation_object['responses']).each do |response|
-            router.add_response(
-              response,
-              request_method:,
-              path:,
-              status: response.status,
-              response_content_type: response.content_type
-            )
+            build_responses(request:, responses: operation_object['responses']).each do |response|
+              router.add_response(
+                response,
+                request_method:,
+                path:,
+                status: response.status,
+                response_content_type: response.content_type
+              )
+            end
           end
         end
       end
@@ -116,18 +116,20 @@ module OpenapiFirst
                     operation_object: operation_object.resolved,
                     parameters:, content_type:,
                     content_schema:,
-                    required_body:)
+                    required_body:,
+                    key: [path, request_method, content_type].join(':'))
       end || []
       return result if required_body
 
       result << Request.new(
         path:, request_method:, operation_object: operation_object.resolved,
         parameters:, content_type: nil, content_schema: nil,
-        required_body:
+        required_body:,
+        key: [path, request_method, nil].join(':')
       )
     end
 
-    def build_responses(responses:)
+    def build_responses(responses:, request:)
       return [] unless responses
 
       responses.flat_map do |status, response_object|
@@ -142,9 +144,10 @@ module OpenapiFirst
                        headers:,
                        headers_schema:,
                        content_type:,
-                       content_schema:)
+                       content_schema:,
+                       key: [request.key, status, content_type].join(':'))
         end || Response.new(status:, headers:, headers_schema:, content_type: nil,
-                            content_schema: nil)
+                            content_schema: nil, key: [request.key, status, nil].join(':'))
       end
     end
 

--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -22,7 +22,7 @@ module OpenapiFirst
       @schemer_configuration.insert_property_defaults = true
 
       @config = config
-      @contents = RefResolver.for(contents, dir: filepath && File.dirname(filepath))
+      @contents = RefResolver.for(contents, filepath:)
     end
 
     attr_reader :config
@@ -108,7 +108,6 @@ module OpenapiFirst
 
     def build_requests(path:, request_method:, operation_object:, parameters:)
       content_objects = operation_object.dig('requestBody', 'content')
-      # binding.irb if request_method == 'post'
       if content_objects.nil?
         return [
           Request.new(path:, request_method:, parameters:,

--- a/lib/openapi_first/configuration.rb
+++ b/lib/openapi_first/configuration.rb
@@ -14,7 +14,7 @@ module OpenapiFirst
       @request_validation_error_response = OpenapiFirst.find_error_response(:default)
       @request_validation_raise_error = false
       @response_validation_raise_error = true
-      @hooks = (HOOKS.map { [_1, []] }).to_h
+      @hooks = (HOOKS.map { [_1, Set.new] }).to_h
     end
 
     attr_reader :request_validation_error_response, :hooks

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -63,7 +63,7 @@ module OpenapiFirst
     # Validates the response against the API description.
     # @param rack_request [Rack::Request] The Rack request object.
     # @param rack_response [Rack::Response] The Rack response object.
-    # @param raise_error [Boolean] Whether to raise an error if validation fails.
+    # @param raise_error [Boolean] Whethir to raise an error if validation fails.
     # @return [ValidatedResponse] The validated response object.
     def validate_response(rack_request, rack_response, raise_error: false)
       route = @router.match(rack_request.request_method, rack_request.path, content_type: rack_request.content_type)

--- a/lib/openapi_first/file_loader.rb
+++ b/lib/openapi_first/file_loader.rb
@@ -8,7 +8,7 @@ module OpenapiFirst
     module_function
 
     def load(file_path)
-      raise FileNotFoundError, "File not found #{file_path}" unless File.exist?(file_path)
+      raise FileNotFoundError, "File not found #{file_path.inspect}" unless File.exist?(file_path)
 
       body = File.read(file_path)
       extname = File.extname(file_path)

--- a/lib/openapi_first/request.rb
+++ b/lib/openapi_first/request.rb
@@ -18,6 +18,7 @@ module OpenapiFirst
       @content_type = content_type
       @content_schema = content_schema
       @operation = operation_object
+      @allow_empty_content = content_type.nil? || required_body == false
       @key = key
       @request_parser = RequestParser.new(
         query_parameters: parameters.query,
@@ -38,6 +39,10 @@ module OpenapiFirst
     # rubocop:enable Metrics/MethodLength
 
     attr_reader :content_type, :content_schema, :operation, :request_method, :path, :key
+
+    def allow_empty_content?
+      @allow_empty_content
+    end
 
     def validate(request, route_params:)
       parsed_request = nil

--- a/lib/openapi_first/request.rb
+++ b/lib/openapi_first/request.rb
@@ -10,13 +10,15 @@ module OpenapiFirst
   # An 3.x Operation object can accept multiple requests, because it can handle multiple content-types.
   # This class represents one of those requests.
   class Request
+    # rubocop:disable Metrics/MethodLength
     def initialize(path:, request_method:, operation_object:,
-                   parameters:, content_type:, content_schema:, required_body:)
+                   parameters:, content_type:, content_schema:, required_body:, key:)
       @path = path
       @request_method = request_method
       @content_type = content_type
       @content_schema = content_schema
       @operation = operation_object
+      @key = key
       @request_parser = RequestParser.new(
         query_parameters: parameters.query,
         path_parameters: parameters.path,
@@ -33,8 +35,9 @@ module OpenapiFirst
         cookie_schema: parameters.cookie_schema
       )
     end
+    # rubocop:enable Metrics/MethodLength
 
-    attr_reader :content_type, :content_schema, :operation, :request_method, :path
+    attr_reader :content_type, :content_schema, :operation, :request_method, :path, :key
 
     def validate(request, route_params:)
       parsed_request = nil

--- a/lib/openapi_first/response.rb
+++ b/lib/openapi_first/response.rb
@@ -9,12 +9,13 @@ module OpenapiFirst
   # This is not a direct reflecton of the OpenAPI 3.X response definition, but a combination of
   # status, content type and content schema.
   class Response
-    def initialize(status:, headers:, headers_schema:, content_type:, content_schema:)
+    def initialize(status:, headers:, headers_schema:, content_type:, content_schema:, key:)
       @status = status
       @content_type = content_type
       @content_schema = content_schema
       @headers = headers
       @headers_schema = headers_schema
+      @key = key
       @parser = ResponseParser.new(headers:, content_type:)
       @validator = ResponseValidator.new(self)
     end
@@ -22,7 +23,7 @@ module OpenapiFirst
     # @attr_reader [Integer] status The HTTP status code of the response definition.
     # @attr_reader [String, nil] content_type Content type of this response.
     # @attr_reader [Schema, nil] content_schema the Schema of the response body.
-    attr_reader :status, :content_type, :content_schema, :headers, :headers_schema
+    attr_reader :status, :content_type, :content_schema, :headers, :headers_schema, :key
 
     def validate(response)
       parsed_values = @parser.parse(response)

--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -32,15 +32,18 @@ module OpenapiFirst
         request_methods.filter_map do |request_method, content|
           next if request_method == :template
 
-          Route.new(path:, request_method:, requests: content[:requests].each_value,
+          Route.new(path:, request_method:, requests: content[:requests].each_value.lazy.uniq,
                     responses: content[:responses].each_value.lazy.flat_map(&:values))
         end
       end
     end
 
     # Add a request definition
-    def add_request(request, request_method:, path:, content_type: nil)
-      route_at(path, request_method)[:requests][content_type] = request
+    def add_request(request, request_method:, path:, content_type: nil, allow_empty_content: false)
+      route = route_at(path, request_method)
+      requests = route[:requests]
+      requests[content_type] = request
+      requests[nil] = request if allow_empty_content
     end
 
     # Add a response definition

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -5,10 +5,23 @@ require_relative 'test/methods'
 module OpenapiFirst
   # Test integration
   module Test
+    autoload :Coverage, 'openapi_first/test/coverage'
+
     def self.minitest?(base)
       base.include?(::Minitest::Assertions)
     rescue NameError
       false
+    end
+
+    # Returns the Rack app wrapped with silent request, response validation
+    # You can use this if you want to track coverage via Test::Coverage, but don't want to use
+    # the middlewares or manual request, response validation.
+    def self.app(app, spec:)
+      Rack::Builder.app do
+        use OpenapiFirst::Middlewares::ResponseValidation, spec:, raise_error: false
+        use OpenapiFirst::Middlewares::RequestValidation, spec:, raise_error: false, error_response: false
+        run app
+      end
     end
 
     class NotRegisteredError < StandardError; end

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-require_relative 'test/methods'
-
 module OpenapiFirst
   # Test integration
   module Test
     autoload :Coverage, 'openapi_first/test/coverage'
+    autoload :Methods, 'openapi_first/test/methods'
 
     def self.minitest?(base)
       base.include?(::Minitest::Assertions)
@@ -13,10 +12,43 @@ module OpenapiFirst
       false
     end
 
+    # Helper class to setup tests
+    class Setup
+      def register(*)
+        Test.register(*)
+      end
+    end
+
+    def self.setup
+      unless block_given?
+        raise ArgumentError, "Please provide a block to #{self.class}.setup to register you API descriptions"
+      end
+
+      Coverage.start
+      setup = Setup.new
+      yield setup
+      return unless definitions.empty?
+
+      raise NotRegisteredError,
+            'No API descriptions have been registered. ' \
+            'Please register your API description via ' \
+            "OpenapiFirst::Test.setup { |test| test.register('myopenapi.yaml') }"
+    end
+
+    # Print the coverage report
+    # @param formatter A formatter to define the report.
+    # @output [IO] An output where to puts the report.
+    def self.report_coverage(formatter: Coverage::TerminalFormatter)
+      coverage_result = Coverage.result
+      puts formatter.new.format(coverage_result)
+      puts "The overal API validation coverage of this run is: #{coverage_result.coverage}%"
+    end
+
     # Returns the Rack app wrapped with silent request, response validation
     # You can use this if you want to track coverage via Test::Coverage, but don't want to use
     # the middlewares or manual request, response validation.
-    def self.app(app, spec:)
+    def self.app(app, spec: nil, api: :default)
+      spec ||= self[api]
       Rack::Builder.app do
         use OpenapiFirst::Middlewares::ResponseValidation, spec:, raise_error: false
         use OpenapiFirst::Middlewares::RequestValidation, spec:, raise_error: false, error_response: false
@@ -25,22 +57,35 @@ module OpenapiFirst
     end
 
     class NotRegisteredError < StandardError; end
+    class AlreadyRegisteredError < StandardError; end
 
-    DEFINITIONS = {} # rubocop:disable Style/MutableConstant
+    @definitions = {}
 
-    def self.definitions = DEFINITIONS
+    class << self
+      attr_reader :definitions
 
-    def self.register(path, as: :default)
-      definitions[as] = OpenapiFirst.load(path)
-    end
+      def register(path, as: :default)
+        if definitions.key?(:default)
+          raise(
+            AlreadyRegisteredError,
+            "#{definitions[as].filepath.inspect} is already registered " \
+            "as ':default' so you cannot register #{path.inspect} without " \
+            'giving it a custom name. Please call register with a custom key like: ' \
+            "OpenapiFirst::Test.register(#{path.inspect}, as: :my_other_api)"
+          )
+        end
 
-    def self.[](api)
-      definitions.fetch(api) do
-        option = api == :default ? '' : ", as: #{api.inspect}"
-        raise(NotRegisteredError,
-              "API description '#{api.inspect}' not found." \
-              "Please call OpenapiFirst::Test.register('myopenapi.yaml'#{option}) " \
-              'once before calling assert_api_conform.')
+        definitions[as] = OpenapiFirst.load(path)
+      end
+
+      def [](api)
+        definitions.fetch(api) do
+          option = api == :default ? '' : ", as: #{api.inspect}"
+          raise(NotRegisteredError,
+                "API description '#{api.inspect}' not found." \
+                "Please call OpenapiFirst::Test.register('myopenapi.yaml'#{option}) " \
+                'once before running tests.')
+        end
       end
     end
   end

--- a/lib/openapi_first/test/coverage.rb
+++ b/lib/openapi_first/test/coverage.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative 'coverage/plan'
+require_relative 'coverage/terminal_formatter'
+
+module OpenapiFirst
+  module Test
+    # The Coverage module is about tracking request and response validation
+    # to assess if all parts of the API description have been tested.
+    # Currently it does not care about unknown requests that are not part of any API description.
+    module Coverage
+      # @visibility private
+      class NotRegisteredError < StandardError; end
+
+      # @visibility private
+      class Configuration
+        def initialize
+          @output = $stdout
+        end
+
+        attr_accessor :output
+      end
+
+      @registry = Hash.new do |_, filepath|
+        raise NotRegisteredError,
+              "API description '#{filepath}' was not registered." \
+              "Please call OpenapiFirst::Coverage.register('path/to/myopenapi.yaml') before calling" \
+              'OpenapiFirst::Coverage.start making requests.' \
+              "Registered descriptions are: #{plans.map(&:filepath)}."
+      end
+
+      @output = $stdout
+
+      class << self
+        attr_reader :registry
+        private attr_writer :output
+
+        def start
+          configuration = Configuration.new.clone
+          yield configuration if block_given?
+
+          self.output = configuration.output
+          @after_request_validation = lambda do |validated_request, oad|
+            track_request(validated_request, oad)
+          end
+
+          @after_response_validation = lambda do |validated_response, request, oad|
+            track_response(validated_response, request, oad)
+          end
+
+          OpenapiFirst.configure do |config|
+            config.after_request_validation(&@after_request_validation)
+            config.after_response_validation(&@after_response_validation)
+          end
+        end
+
+        def stop
+          configuration = OpenapiFirst.configuration
+          configuration.hooks[:after_request_validation].delete(@after_request_validation)
+          configuration.hooks[:after_response_validation].delete(@after_response_validation)
+        end
+
+        # Add OAD where coverage should be tracked.
+        def register(*filepaths)
+          filepaths.each do |filepath|
+            oad = OpenapiFirst.load(filepath)
+            registry[oad.filepath] = oad
+          end
+        end
+
+        # Remove all OADs from registry.
+        def reset
+          @current_run = nil
+        end
+
+        def track_request(request, oad)
+          current_run[oad.filepath].track_request(request)
+        end
+
+        def track_response(response, _request, oad)
+          current_run[oad.filepath].track_response(response)
+        end
+
+        # Print the coverage report
+        # @param formatter A formatter to define the report.
+        # @output [IO] An output where to puts the report.
+        def report(formatter: TerminalFormatter, output: $stdout)
+          output.puts formatter.new.format(plans)
+        end
+
+        # Returns all plans (Plan) that were registered for this run
+        def plans
+          current_run.values
+        end
+
+        private
+
+        def current_run
+          @current_run ||= registry.transform_values do |oad|
+            Plan.new(oad)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/coverage/plan.rb
+++ b/lib/openapi_first/test/coverage/plan.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative 'response_task'
+require_relative 'request_task'
+
+module OpenapiFirst
+  module Test
+    module Coverage
+      # This stores the coverage data for one API description
+      # A plan can be #done? and has several #tasks which can be #finished?
+      class Plan
+        class UnknownRequestError < StandardError; end
+
+        def initialize(oad)
+          @oad = oad
+          @index = {}
+          @filepath = oad.filepath
+          oad.routes.each do |route|
+            route.requests.each do |request|
+              add request:, responses: route.responses.to_a
+            end
+          end
+        end
+
+        attr_reader :filepath, :oad
+        private attr_reader :index
+
+        def track_request(validated_request)
+          index[validated_request.request_definition.key].track(validated_request) if validated_request.known?
+        end
+
+        def track_response(validated_response)
+          index[validated_response.response_definition.key].track(validated_response) if validated_response.known?
+        end
+
+        def done?
+          tasks.all?(&:finished?)
+        end
+
+        def requests
+          tasks.filter(&:request?)
+        end
+
+        def tasks
+          index.values
+        end
+
+        def coverage
+          done = tasks.count(&:finished?)
+          return 0 if done.zero?
+
+          all = tasks.count
+          (done / (all.to_f / 100)).to_i
+        end
+
+        private
+
+        def add(request:, responses:)
+          response_tasks = responses.map do |response|
+            ResponseTask.new(response)
+          end
+          index[request.key] = RequestTask.new(request, responses: response_tasks)
+          response_tasks.each do |task|
+            index[task.key] = task
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/coverage/request_task.rb
+++ b/lib/openapi_first/test/coverage/request_task.rb
@@ -19,8 +19,9 @@ module OpenapiFirst
 
         attr_reader :request, :responses
 
-        def track(_request)
+        def track(validated_request)
           @requested = true
+          @valid ||= true if validated_request.valid?
         end
 
         def request?
@@ -35,7 +36,13 @@ module OpenapiFirst
           @requested == true
         end
 
-        alias finished? requested?
+        def any_valid_request?
+          @valid == true
+        end
+
+        def finished?
+          requested? && any_valid_request?
+        end
 
         def unfinished?
           !finished?

--- a/lib/openapi_first/test/coverage/request_task.rb
+++ b/lib/openapi_first/test/coverage/request_task.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module OpenapiFirst
+  module Test
+    module Coverage
+      # @visibility private
+      class RequestTask
+        extend Forwardable
+
+        def_delegators :@request, :path, :request_method, :content_type
+
+        def initialize(request_definition, responses:)
+          @request = request_definition
+          @responses = responses
+          @requested = false
+        end
+
+        attr_reader :request, :responses
+
+        def track(_request)
+          @requested = true
+        end
+
+        def request?
+          true
+        end
+
+        def response?
+          false
+        end
+
+        def requested?
+          @requested == true
+        end
+
+        alias finished? requested?
+
+        def unfinished?
+          !finished?
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/coverage/request_task.rb
+++ b/lib/openapi_first/test/coverage/request_task.rb
@@ -11,25 +11,16 @@ module OpenapiFirst
 
         def_delegators :@request, :path, :request_method, :content_type
 
-        def initialize(request_definition, responses:)
+        def initialize(request_definition)
           @request = request_definition
-          @responses = responses
           @requested = false
         end
 
-        attr_reader :request, :responses
+        attr_reader :request
 
         def track(validated_request)
           @requested = true
           @valid ||= true if validated_request.valid?
-        end
-
-        def request?
-          true
-        end
-
-        def response?
-          false
         end
 
         def requested?
@@ -42,10 +33,6 @@ module OpenapiFirst
 
         def finished?
           requested? && any_valid_request?
-        end
-
-        def unfinished?
-          !finished?
         end
       end
     end

--- a/lib/openapi_first/test/coverage/response_task.rb
+++ b/lib/openapi_first/test/coverage/response_task.rb
@@ -18,8 +18,9 @@ module OpenapiFirst
 
         attr_reader :response
 
-        def track(_response)
+        def track(validated_response)
           @responded = true
+          @valid ||= true if validated_response.valid?
         end
 
         def request?
@@ -34,7 +35,13 @@ module OpenapiFirst
           @responded == true
         end
 
-        alias finished? responded?
+        def any_valid_response?
+          @valid == true
+        end
+
+        def finished?
+          responded? && any_valid_response?
+        end
 
         def unfinished?
           !finished?

--- a/lib/openapi_first/test/coverage/response_task.rb
+++ b/lib/openapi_first/test/coverage/response_task.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module OpenapiFirst
+  module Test
+    module Coverage
+      # @visibility private
+      class ResponseTask
+        extend Forwardable
+
+        def_delegators :@response, :status, :content_type, :key
+
+        def initialize(response_definition)
+          @response = response_definition
+          @responded = false
+        end
+
+        attr_reader :response
+
+        def track(_response)
+          @responded = true
+        end
+
+        def request?
+          false
+        end
+
+        def response?
+          true
+        end
+
+        def responded?
+          @responded == true
+        end
+
+        alias finished? responded?
+
+        def unfinished?
+          !finished?
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/coverage/response_task.rb
+++ b/lib/openapi_first/test/coverage/response_task.rb
@@ -23,14 +23,6 @@ module OpenapiFirst
           @valid ||= true if validated_response.valid?
         end
 
-        def request?
-          false
-        end
-
-        def response?
-          true
-        end
-
         def responded?
           @responded == true
         end
@@ -41,10 +33,6 @@ module OpenapiFirst
 
         def finished?
           responded? && any_valid_response?
-        end
-
-        def unfinished?
-          !finished?
         end
       end
     end

--- a/lib/openapi_first/test/coverage/route_task.rb
+++ b/lib/openapi_first/test/coverage/route_task.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  module Test
+    module Coverage
+      RouteTask = Data.define(:path, :request_method, :requests, :responses) do
+        def finished?
+          requests.all?(&:finished?) && responses.all?(&:finished?)
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/coverage/terminal_formatter.rb
+++ b/lib/openapi_first/test/coverage/terminal_formatter.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  module Test
+    module Coverage
+      # This is the default formatter
+      class TerminalFormatter
+        # This takes a list of Coverage::Plan instances and outputs a String
+        def format(plans)
+          @out = StringIO.new
+          plans.each { |plan| format_plan(plan) }
+          @out.string
+        end
+
+        private attr_reader :out
+
+        private
+
+        def puts(string)
+          @out.puts(string)
+        end
+
+        def print(string)
+          @out.print(string)
+        end
+
+        def format_plan(plan)
+          filepath = plan.filepath
+          puts ['', "API validation coverage for #{filepath}: #{plan.coverage}%"]
+          return if plan.done?
+
+          plan.requests.each do |request|
+            if request.requested?
+              if request.responses.all?(&:finished?)
+                puts green "✓ #{request_label(request)}"
+              else
+                puts orange "⚠ #{request_label(request)}"
+              end
+            else
+              puts red "❌ #{request_label(request)} – Not requested!"
+              next
+            end
+
+            request.responses.each do |response|
+              if response.responded?
+                # puts green "  ✓ #{response_label(response)}"
+                next
+              end
+
+              puts red "  ❌ #{response_label(response)}"
+            end
+          end
+        end
+
+        def green(text)
+          "\e[32m#{text}\e[0m"
+        end
+
+        def red(text)
+          "\e[31m#{text}\e[0m"
+        end
+
+        def orange(text)
+          "\e[33m#{text}\e[0m"
+        end
+
+        def request_label(request)
+          name = "#{request.request_method.upcase} #{request.path}" # TODO: add required query parameters?
+          name << " (#{request.content_type})" if request.content_type
+          name
+        end
+
+        def response_label(response)
+          name = response.status.to_s
+          return(name + " (#{response.content_type})") if response.content_type
+
+          name
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/methods.rb
+++ b/lib/openapi_first/test/methods.rb
@@ -4,7 +4,6 @@ require_relative 'minitest_helpers'
 require_relative 'plain_helpers'
 
 module OpenapiFirst
-  # Test integration
   module Test
     # Methods to use in integration tests
     module Methods

--- a/lib/openapi_first/validated_response.rb
+++ b/lib/openapi_first/validated_response.rb
@@ -39,6 +39,9 @@ module OpenapiFirst
       error.nil?
     end
 
+    # Returns true if the response is defined.
+    def known? = response_definition != nil
+
     # Checks if the response is invalid.
     # @return [Boolean]
     def invalid?

--- a/spec/data/dice.yaml
+++ b/spec/data/dice.yaml
@@ -1,0 +1,12 @@
+openapi: 3.1.0
+paths:
+  "/roll":
+    post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: integer
+                min: 1
+                max: 6

--- a/spec/data/request-body-validation.yaml
+++ b/spec/data/request-body-validation.yaml
@@ -14,6 +14,21 @@ info:
 servers:
   - url: http://petstore.swagger.io/api
 paths:
+  /optional-request-body:
+    post:
+      requestBody:
+          # required: false # false is the default \o/
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - say
+                properties:
+                  say:
+                    type: string
+                    enum:
+                      - 'yes'
   /pets:
     post:
       description: Creates a new pet in the store.  Duplicates are allowed

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -306,6 +306,18 @@ RSpec.describe OpenapiFirst::Definition do
       routes = definition.routes.map { |route| "#{route.request_method} #{route.path}" }
       expect(routes).to match_array ['GET /stations', 'GET /trips', 'GET /bookings', 'POST /bookings', 'GET /bookings/{bookingId}', 'DELETE /bookings/{bookingId}', 'POST /bookings/{bookingId}/payment']
     end
+
+    it 'has a different key for each request and response' do
+      requests_keys = definition.routes.flat_map { |route| route.requests.map(&:key) }
+      expect(requests_keys.all?(Integer))
+      expect(requests_keys.count).to eq(requests_keys.uniq.count)
+
+      response_keys = definition.routes.flat_map { |route| route.responses.map(&:key) }
+      expect(response_keys.all?(Integer))
+      expect(response_keys.count).to eq(response_keys.uniq.count)
+
+      expect((requests_keys + response_keys).uniq.count).to eq(requests_keys.count + response_keys.count)
+    end
   end
 
   describe '#router' do

--- a/spec/file_loader_spec.rb
+++ b/spec/file_loader_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OpenapiFirst::FileLoader do
     end
 
     it 'raises FileNotFoundError if file was not found' do
-      expect { described_class.load('./spec/data/unknown.yaml') }.to raise_error(OpenapiFirst::FileNotFoundError, 'File not found ./spec/data/unknown.yaml')
+      expect { described_class.load('./spec/data/unknown.yaml') }.to raise_error(OpenapiFirst::FileNotFoundError, 'File not found "./spec/data/unknown.yaml"')
     end
   end
 end

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -5,6 +5,24 @@ RSpec.describe 'Hooks' do
     Rack::Request.new(Rack::MockRequest.env_for(path, method:, input: body, 'CONTENT_TYPE' => 'application/json'))
   end
 
+  describe 'adding and removing a hook' do
+    specify do
+      called = []
+      myproc = proc do |request|
+        called << [request.operation_id, request.valid?]
+      end
+
+      definition = OpenapiFirst.load('./spec/data/petstore.yaml') do |config|
+        config.after_request_validation(&myproc)
+      end
+      definition.validate_request(build_request('/pets?limit=24'))
+      definition.config.hooks[:after_request_validation].delete(myproc)
+      definition.validate_request(build_request('/pets?limit=24'))
+
+      expect(called).to eq([['listPets', true]])
+    end
+  end
+
   describe 'after_request_validation' do
     let(:called) { [] }
     let(:definition) do

--- a/spec/middlewares/request_validation/request_body_validation_spec.rb
+++ b/spec/middlewares/request_validation/request_body_validation_spec.rb
@@ -38,10 +38,6 @@ RSpec.describe 'Request body validation' do
       }
     end
 
-    let(:response_body) do
-      JSON.parse(last_response.body, symbolize_names: true)
-    end
-
     it 'works with stringio' do
       header Rack::CONTENT_TYPE, 'application/json'
       io = StringIO.new(JSON.generate(request_body))

--- a/spec/middlewares/request_validation/request_body_validation_spec.rb
+++ b/spec/middlewares/request_validation/request_body_validation_spec.rb
@@ -204,6 +204,32 @@ RSpec.describe 'Request body validation' do
       expect(last_response.status).to be 400
     end
 
+    context 'when request body is optional' do
+      let(:path) { '/optional-request-body' }
+
+      it 'accepts a valid request body' do
+        header Rack::CONTENT_TYPE, 'application/json'
+        post path, JSON.generate({ say: 'yes' })
+
+        expect(last_response.status).to be(200), last_response.body
+        expect(last_request.env[OpenapiFirst::REQUEST].parsed_body).to eq 'say' => 'yes'
+      end
+
+      it 'accepts an empty request body' do
+        post path
+
+        expect(last_response.status).to be(200), last_response.body
+        expect(last_request.env[OpenapiFirst::REQUEST].parsed_body).to eq nil
+      end
+
+      it 'returns 400 if request body is invalid' do
+        header Rack::CONTENT_TYPE, 'application/json'
+        post path, JSON.generate({ say: 'no ' })
+
+        expect(last_response.status).to be(400), last_response.body
+      end
+    end
+
     context 'with default values' do
       before { header Rack::CONTENT_TYPE, 'application/json' }
 

--- a/spec/ref_resolver_spec.rb
+++ b/spec/ref_resolver_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe OpenapiFirst::RefResolver do
 
   describe '#dir' do
     it 'returns the directory path' do
-      file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
-      doc = described_class.load(file_path)
+      filepath = './spec/data/splitted-train-travel-api/openapi.yaml'
+      doc = described_class.load(filepath)
       expect(doc.dir).to eq(File.expand_path('./spec/data/splitted-train-travel-api'))
 
       node = doc['paths']['/stations']['get']
@@ -39,29 +39,29 @@ RSpec.describe OpenapiFirst::RefResolver do
 
   describe '#context' do
     it 'returns contents of the main file' do
-      file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
-      doc = described_class.load(file_path)
+      filepath = './spec/data/splitted-train-travel-api/openapi.yaml'
+      doc = described_class.load(filepath)
       node = doc['info']
       expect(node.context['openapi']).to eq('3.1.0')
     end
 
     it 'returns contents of the main file when following internal refs' do
-      file_path = './spec/data/train-travel-api/openapi.yaml'
-      doc = described_class.load(file_path)
+      filepath = './spec/data/train-travel-api/openapi.yaml'
+      doc = described_class.load(filepath)
       node = doc['paths']['/stations']['get']['responses']['200']['headers']['RateLimit']['schema']
       expect(node.context['openapi']).to eq('3.1.0')
     end
 
     it 'returns contents of the referenced file' do
-      file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
-      doc = described_class.load(file_path)
+      filepath = './spec/data/splitted-train-travel-api/openapi.yaml'
+      doc = described_class.load(filepath)
       node = doc['paths']['/stations']['get']['responses']
       expect(node.context.dig('get', 'description')).to start_with('Returns a list of all train stations')
     end
 
     it 'returns contents of the referenced file when pointing inside referenced files' do
-      file_path = './spec/data/petstore.yaml'
-      doc = described_class.load(file_path)
+      filepath = './spec/data/petstore.yaml'
+      doc = described_class.load(filepath)
       node = doc['components']['schemas']['Pet']['required']
       expect(node.context).to eq(YAML.load_file('./spec/data/components/schemas/pet.yaml'))
     end
@@ -105,18 +105,18 @@ RSpec.describe OpenapiFirst::RefResolver do
 
   describe '#[]' do
     it 'works across files' do
-      file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
-      contents = OpenapiFirst::FileLoader.load(file_path)
-      doc = described_class.for(contents, dir: File.dirname(file_path))
+      filepath = './spec/data/splitted-train-travel-api/openapi.yaml'
+      contents = OpenapiFirst::FileLoader.load(filepath)
+      doc = described_class.for(contents, filepath:)
       node = doc['paths']['/stations']['get']['responses']['200']['headers']['RateLimit']['schema']
       expect(node.context['description']).to start_with('The RateLimit header')
       expect(node.resolved['type']).to eq('string')
     end
 
     it 'follows pointers through files' do
-      file_path = './spec/data/petstore.yaml'
-      contents = OpenapiFirst::FileLoader.load(file_path)
-      doc = described_class.for(contents, dir: File.dirname(file_path))
+      filepath = './spec/data/petstore.yaml'
+      contents = OpenapiFirst::FileLoader.load(filepath)
+      doc = described_class.for(contents, filepath:)
       target = doc['components']['schemas']['Pet']
 
       expect(target.value).to eq({ '$ref' => './components/schemas/pet.yaml#/Pet' })
@@ -141,18 +141,18 @@ RSpec.describe OpenapiFirst::RefResolver do
 
   describe '#dig' do
     it 'works across files' do
-      file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
-      contents = OpenapiFirst::FileLoader.load(file_path)
-      doc = described_class.for(contents, dir: File.dirname(file_path))
+      filepath = './spec/data/splitted-train-travel-api/openapi.yaml'
+      contents = OpenapiFirst::FileLoader.load(filepath)
+      doc = described_class.for(contents, filepath:)
       node = doc.dig('paths', '/stations', 'get', 'responses', '200', 'headers', 'RateLimit', 'schema')
       expect(node.context['description']).to start_with('The RateLimit header')
       expect(node.resolved['type']).to eq('string')
     end
 
     it 'follows pointers through files' do
-      file_path = './spec/data/petstore.yaml'
-      contents = OpenapiFirst::FileLoader.load(file_path)
-      doc = described_class.for(contents, dir: File.dirname(file_path))
+      filepath = './spec/data/petstore.yaml'
+      contents = OpenapiFirst::FileLoader.load(filepath)
+      doc = described_class.for(contents, filepath:)
       target = doc.dig('components', 'schemas', 'Pet')
 
       expect(target.value).to eq({ '$ref' => './components/schemas/pet.yaml#/Pet' })
@@ -181,9 +181,9 @@ RSpec.describe OpenapiFirst::RefResolver do
 
   describe '#fetch' do
     it 'works across files' do
-      file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
-      contents = OpenapiFirst::FileLoader.load(file_path)
-      doc = described_class.for(contents, dir: File.dirname(file_path))
+      filepath = './spec/data/splitted-train-travel-api/openapi.yaml'
+      contents = OpenapiFirst::FileLoader.load(filepath)
+      doc = described_class.for(contents, filepath:)
       target = doc.fetch('paths').fetch('/stations')['get']['responses']['200']['headers']['RateLimit']['schema']
       expect(target.resolved['type']).to eq('string')
     end
@@ -219,9 +219,9 @@ RSpec.describe OpenapiFirst::RefResolver do
 
   describe '#each' do
     it 'works across files' do
-      file_path = './spec/data/splitted-train-travel-api/openapi.yaml'
-      contents = OpenapiFirst::FileLoader.load(file_path)
-      doc = described_class.for(contents, dir: File.dirname(file_path))
+      filepath = './spec/data/splitted-train-travel-api/openapi.yaml'
+      contents = OpenapiFirst::FileLoader.load(filepath)
+      doc = described_class.for(contents, filepath:)
 
       items = []
       doc.fetch('paths').each { |path, path_item| items << [path, path_item] }

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -86,6 +86,29 @@ RSpec.describe OpenapiFirst::Router do
       end
     end
 
+    context 'with optional request body' do
+      subject(:router) do
+        described_class.new.tap do |router|
+          router.add_request(1, request_method: 'post', path: '/stations', content_type: 'application/json', allow_empty_content: true)
+        end
+      end
+
+      it 'accepts a matching content_type' do
+        match = router.match('POST', '/stations', content_type: 'application/json')
+        expect(match.request_definition).to eq(1)
+      end
+
+      it 'accepts an empty content_type' do
+        match = router.match('POST', '/stations', content_type: nil)
+        expect(match.request_definition).to eq(1)
+      end
+
+      it 'accepts a content-type mismatch' do
+        match = router.match('POST', '/stations', content_type: 'application/xml')
+        expect(match.request_definition).to eq(1)
+      end
+    end
+
     context 'with different variables in common nested routes' do
       let(:requests) do
         [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'rack/test'
 SimpleCov.start do
   enable_coverage :branch
   primary_coverage :branch
+  add_filter 'lib/openapi_first/test/coverage/'
 end
 
 SimpleCov.minimum_coverage line: 99, branch: 85
@@ -27,6 +28,6 @@ RSpec.configure do |config|
   end
 
   config.after do
-    OpenapiFirst::Test::DEFINITIONS.clear
+    OpenapiFirst::Test.definitions.clear
   end
 end

--- a/spec/test/coverage/plan_spec.rb
+++ b/spec/test/coverage/plan_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::Test::Coverage::Plan do
+  let(:spec) do
+    {
+      'openapi' => '3.1.0',
+      'paths' => {
+        '/stuff/{id}' => {
+          'parameters' => [
+            {
+              'name' => 'id',
+              'in' => 'path',
+              'required' => true,
+              'schema' => {
+                'type' => 'integer'
+              }
+            }
+          ],
+          'get' => {
+            'responses' => {
+              '200' => {
+                'content' => {
+                  'application/json' => {
+                    'schema' => {
+                      'type' => 'object'
+                    }
+                  }
+                }
+              },
+              '4XX' => {
+                'content' => {
+                  'application/json' => {
+                    'schema' => {
+                      'type' => 'object'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  end
+
+  let(:oad) { OpenapiFirst.parse(spec, filepath: 'myopenapi.yaml') }
+
+  let(:valid_request) do
+    request = Rack::Request.new(Rack::MockRequest.env_for('/stuff/24'))
+    oad.validate_request(request)
+  end
+
+  let(:valid_response) do
+    request = Rack::Request.new(Rack::MockRequest.env_for('/stuff/24'))
+    response = Rack::Response.new
+    response.content_type = 'application/json'
+    response.write JSON.generate({})
+    oad.validate_response(request, response)
+  end
+
+  let(:valid_400_response) do
+    request = Rack::Request.new(Rack::MockRequest.env_for('/stuff/24'))
+    response = Rack::Response.new
+    response.status = 400
+    response.content_type = 'application/json'
+    response.write JSON.generate({})
+    oad.validate_response(request, response)
+  end
+
+  subject(:plan) { described_class.new(oad) }
+
+  it 'has requests and responses' do
+    request = plan.requests.first
+    expect(request.requested?).to be(false)
+    expect(request.path).to eq('/stuff/{id}')
+    expect(request.request_method).to eq('get')
+    expect(request.content_type).to eq(nil)
+
+    response = request.responses.first
+    expect(response.responded?).to be(false)
+    expect(response.status).to eq('200')
+    expect(response.content_type).to eq('application/json')
+  end
+
+  it 'tracks requests and responses' do
+    request = plan.requests.first
+    expect(request.requested?).to be(false)
+
+    plan.track_request(valid_request)
+
+    expect(request.requested?).to be(true)
+
+    response = request.responses.first
+    expect(response.responded?).to be(false)
+
+    plan.track_response(valid_response)
+
+    expect(response.responded?).to be(true)
+  end
+
+  it 'ignores unknown requests' do
+    request = Rack::Request.new(Rack::MockRequest.env_for('/unknown/24'))
+    plan.track_request(oad.validate_request(request))
+    expect(plan.coverage).to eq(0)
+  end
+
+  it 'ignores unknown responses' do
+    request = Rack::Request.new(Rack::MockRequest.env_for('/stuff/24'))
+    response = Rack::Response.new
+    response.status = 309
+    plan.track_response(oad.validate_response(request, response))
+    expect(plan.coverage).to eq(0)
+  end
+
+  it 'returns coverage in percentage' do
+    expect(plan.coverage).to eq(0)
+
+    plan.track_request(valid_request)
+    plan.track_response(valid_response)
+    expect(plan.coverage).to eq(66)
+    plan.track_response(valid_400_response)
+
+    expect(plan.coverage).to eq(100)
+  end
+
+  it 'can be done' do
+    expect(plan).not_to be_done
+
+    plan.track_request(valid_request)
+    plan.track_response(valid_response)
+    plan.track_response(valid_400_response)
+
+    expect(plan).to be_done
+  end
+
+  it 'has tasks, finished and unfinished' do
+    expect(plan.tasks.count).to eq(3)
+    expect(plan.tasks.count(&:request?)).to eq(1)
+    expect(plan.tasks.count(&:response?)).to eq(2)
+
+    expect(plan.tasks.count(&:finished?)).to eq(0)
+    expect(plan.tasks.count(&:unfinished?)).to eq(3)
+
+    plan.track_request(valid_request)
+    plan.track_response(valid_response)
+    plan.track_response(valid_400_response)
+
+    expect(plan.tasks.count(&:finished?)).to eq(3)
+    expect(plan.tasks.count(&:unfinished?)).to eq(0)
+  end
+
+  it 'has ordered tasks' do
+    expect(plan.tasks[0]).to be_request
+    expect(plan.tasks[0].path).to eq('/stuff/{id}')
+    expect(plan.tasks[1]).to be_response
+    expect(plan.tasks[1].status).to eq('200')
+    expect(plan.tasks[2]).to be_response
+    expect(plan.tasks[2].status).to eq('4XX')
+  end
+end

--- a/spec/test/coverage/plan_spec.rb
+++ b/spec/test/coverage/plan_spec.rb
@@ -69,28 +69,15 @@ RSpec.describe OpenapiFirst::Test::Coverage::Plan do
 
   subject(:plan) { described_class.new(oad) }
 
-  it 'has requests and responses' do
-    request = plan.requests.first
-    expect(request.requested?).to be(false)
-    expect(request.path).to eq('/stuff/{id}')
-    expect(request.request_method).to eq('get')
-    expect(request.content_type).to eq(nil)
-
-    response = request.responses.first
-    expect(response.responded?).to be(false)
-    expect(response.status).to eq('200')
-    expect(response.content_type).to eq('application/json')
-  end
-
   it 'tracks requests and responses' do
-    request = plan.requests.first
+    request = plan.routes.first.requests.first
     expect(request.requested?).to be(false)
 
     plan.track_request(valid_request)
 
     expect(request.requested?).to be(true)
 
-    response = request.responses.first
+    response = plan.routes.first.responses.first
     expect(response.responded?).to be(false)
 
     plan.track_response(valid_response)
@@ -135,26 +122,19 @@ RSpec.describe OpenapiFirst::Test::Coverage::Plan do
 
   it 'has tasks, finished and unfinished' do
     expect(plan.tasks.count).to eq(3)
-    expect(plan.tasks.count(&:request?)).to eq(1)
-    expect(plan.tasks.count(&:response?)).to eq(2)
 
     expect(plan.tasks.count(&:finished?)).to eq(0)
-    expect(plan.tasks.count(&:unfinished?)).to eq(3)
 
     plan.track_request(valid_request)
     plan.track_response(valid_response)
     plan.track_response(valid_400_response)
 
     expect(plan.tasks.count(&:finished?)).to eq(3)
-    expect(plan.tasks.count(&:unfinished?)).to eq(0)
   end
 
   it 'has ordered tasks' do
-    expect(plan.tasks[0]).to be_request
     expect(plan.tasks[0].path).to eq('/stuff/{id}')
-    expect(plan.tasks[1]).to be_response
     expect(plan.tasks[1].status).to eq('200')
-    expect(plan.tasks[2]).to be_response
     expect(plan.tasks[2].status).to eq('4XX')
   end
 end

--- a/spec/test/coverage_spec.rb
+++ b/spec/test/coverage_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::Test::Coverage do
+  let(:filepath) { './spec/data/dice.yaml' }
+  let(:definition) { OpenapiFirst.load(filepath) }
+
+  before(:each) do
+    described_class.register(filepath)
+    described_class.start
+  end
+
+  after(:each) do
+    described_class.stop
+    described_class.reset
+  end
+
+  let(:valid_request) { Rack::Request.new(Rack::MockRequest.env_for('/roll', method: 'POST')) }
+
+  let(:valid_response) do
+    Rack::Response[200, { 'content-type' => 'application/json' }, ['1']]
+  end
+
+  describe '.register' do
+    it 'accepts filepaths' do
+      filepath1 = 'spec/data/petstore.yaml'
+      filepath2 = 'spec/data/train-travel-api/openapi.yaml'
+      expect(described_class.register(filepath1, filepath2)).to be_truthy
+      oad1 = OpenapiFirst.load(filepath1)
+      oad2 = OpenapiFirst.load(filepath2)
+      expect(described_class.registry[oad1.filepath].filepath).to eq(oad1.filepath)
+      expect(described_class.registry[oad2.filepath].filepath).to eq(oad2.filepath)
+    end
+  end
+
+  describe '.start' do
+    before { described_class.stop }
+
+    it 'accepts a block' do
+      myio = StringIO.new
+      described_class.start do |config|
+        config.output = myio
+      end
+    end
+  end
+
+  describe '.report' do
+    def output
+      io = StringIO.new
+      described_class.report(output: io)
+      io.string
+    end
+
+    context 'without any requests' do
+      specify { expect(output).to include(': 0%') }
+    end
+
+    context 'with full coverage' do
+      before do
+        definition.validate_request(valid_request)
+        definition.validate_response(valid_request, valid_response)
+      end
+
+      specify { expect(output).to include(': 100%') }
+    end
+
+    context 'with partly coverage' do
+      before do
+        definition.validate_request(valid_request)
+      end
+
+      specify { expect(output).to include(': 50%') }
+    end
+  end
+end

--- a/spec/test/methods_spec.rb
+++ b/spec/test/methods_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::Test::Methods do
+  it 'can be included' do
+    minitest_class = Class.new(Minitest::Test) do
+      include OpenapiFirst::Test::Methods
+    end
+    expect(minitest_class.included_modules).to include(OpenapiFirst::Test::MinitestHelpers)
+
+    other_class = Class.new do
+      include OpenapiFirst::Test::Methods
+    end
+    expect(other_class.included_modules).to include(OpenapiFirst::Test::PlainHelpers)
+  end
+
+  it 'detects wrong response status for Minitest' do
+    OpenapiFirst::Test.register('./examples/openapi.yaml')
+    minitest_class = Class.new(Minitest::Test) do
+      include OpenapiFirst::Test::Methods
+
+      def last_request = Rack::Request.new(Rack::MockRequest.env_for('/'))
+      def last_response = Rack::Response.new
+    end
+
+    expect do
+      minitest_class.new('hey').assert_api_conform(status: 444)
+    end.to raise_error(Minitest::Assertion)
+  end
+
+  it 'detects wrong response status for non Minitest' do
+    OpenapiFirst::Test.register('./examples/openapi.yaml')
+    minitest_class = Class.new do
+      include OpenapiFirst::Test::Methods
+
+      def last_request = Rack::Request.new(Rack::MockRequest.env_for('/'))
+      def last_response = Rack::Response.new
+    end
+
+    expect do
+      minitest_class.new.assert_api_conform(status: 444)
+    end.to raise_error(OpenapiFirst::Error)
+  end
+end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe OpenapiFirst::Test do
       described_class.report_coverage
       expect(output.string).to include('0%')
     end
+
+    it 'reports 0% if ' do
+      described_class.setup do |test|
+        test.register('./spec/data/dice.yaml')
+      end
+
+      definition = OpenapiFirst.load('./spec/data/dice.yaml')
+      valid_request = Rack::Request.new(Rack::MockRequest.env_for('/roll', method: 'POST'))
+      definition.validate_request(valid_request)
+
+      output = StringIO.new
+      allow($stdout).to receive(:puts).and_invoke(output.method(:puts))
+      described_class.report_coverage
+      expect(output.string).to include('0%')
+    end
   end
 
   describe '.app' do

--- a/spec/validated_request_spec.rb
+++ b/spec/validated_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OpenapiFirst::ValidatedRequest do
       Rack::Request.new(Rack::MockRequest.env_for('/')),
       parsed_request:,
       error: nil,
-      request_definition: double(:request_definition)
+      request_definition: double(:request_definition, key: 1)
     )
   end
 


### PR DESCRIPTION
This adds OpenapiFirst::Test::Coverage to track request/response coverage for your API descriptions. 
This also adds a OpenapiFirst::Test.setup method to set it up.

Currently this setup always prints the coverage result to stdout. Currently there is no configuration to set a minimum coverage value or change the exit code.

To check the overall coverage after your test runs manually, you can call `OpenapiFirst::Test::Coverage.result.coverage`.

<img width="510" alt="Screenshot 2025-02-14 at 19 10 01" src="https://github.com/user-attachments/assets/20c3c891-5bea-4ed9-a703-e51df3b566bc" />

Here is how to set it up for RSpec in your `spec/spec_helper.rb`:

1. Register all OpenAPI documents to track coverage for and start tracking. This should go at the top of you test helper file before loading application code.
  ```ruby
  require 'openapi_first'
  OpenapiFirst::Test.setup do |test|
    test.register('openapi/openapi.yaml')
  end
  ```
2. Wrap your app with silent request / response validation. This validates all requets/responses you do during your test run. (✷1)
  ```ruby
  config.before type: :request do
    def app
      OpenapiFirst::Test::(App)
    end
  end
  ```
3. Check coverage after your test suite has finished
  ```ruby
  # Prints a coverage report to the terminal
  config.after(:suite) { OpenapiFirst::Test.report_coverage }
  ```