### PR TITLE
2.4.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require: rubocop-performance
+plugins: rubocop-performance
 AllCops:
   TargetRubyVersion: 3.2.0
   NewCops: enable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.4.0
+
 - Add `verbose` option to `OpenapiFirst::Test.report_coverage(verbose: true)`
   to see all passing requests/responses
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `verbose` option to `OpenapiFirst::Test.report_coverage(verbose: true)`
+  to see all passing requests/responses
+
 ## 2.3.0
 
 ### New feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 2.4.0
 
+- Support less verbose test setup without the need to call `OpenapiFirst::Test.report_coverage`, which will be called `at_exit`:
+  ```ruby
+  OpenapiFirst::Test.setup do |test|
+    test.register('openapi/openapi.yaml')
+    test.minimum_coverage = 100 # Setting this will lead to an `exit 2` if coverage is below minimum
+  end
+  ```
+- Add `OpenapiFirst::Test::Setup#minimum_coverage=` to control exit behaviour (exit 2 if coverage is below minimum)
 - Add `verbose` option to `OpenapiFirst::Test.report_coverage(verbose: true)`
   to see all passing requests/responses
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (2.3.0)
+    openapi_first (2.4.0)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.3.3, < 2.0)
@@ -109,7 +109,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
-    rubocop (1.72.0)
+    rubocop (1.73.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -120,11 +120,12 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.0)
+    rubocop-ast (1.38.1)
       parser (>= 3.3.1.0)
-    rubocop-performance (1.23.1)
-      rubocop (>= 1.48.1, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-performance (1.24.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     simplecov (0.22.0)
@@ -139,7 +140,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.2)
+    uri (1.0.3)
     useragent (0.16.11)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Here is how to set it up for RSpec in your `spec/spec_helper.rb`:
   require 'openapi_first'
   OpenapiFirst::Test.setup do |test|
     test.register('openapi/openapi.yaml')
+    test.minimum_coverage = 100 # Setting this will lead to an `exit 2` if coverage is below minimum
   end
   ```
 2. Wrap your app with silent request / response validation. This validates all requets/responses you do during your test run. (✷1)
@@ -160,11 +161,6 @@ Here is how to set it up for RSpec in your `spec/spec_helper.rb`:
       OpenapiFirst::Test.app(App)
     end
   end
-  ```
-3. Check coverage after your test suite has finished
-  ```ruby
-  # Prints a coverage report to the terminal
-  config.after(:suite) { OpenapiFirst::Test.report_coverage }
   ```
 
 (✷1): Instead of using `OpenapiFirstTest.app` to wrap your application, you can use the middlewares or [test assertion method](#test-assertions), but you would have to do that for all requests/responses defined in your API description to make coverage work.

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (2.3.0)
+    openapi_first (2.4.0)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.3.3, < 2.0)

--- a/lib/openapi_first/response.rb
+++ b/lib/openapi_first/response.rb
@@ -26,8 +26,12 @@ module OpenapiFirst
     attr_reader :status, :content_type, :content_schema, :headers, :headers_schema, :key
 
     def validate(response)
-      parsed_values = @parser.parse(response)
-      error = @validator.call(parsed_values)
+      parsed_values = nil
+      error = catch FAILURE do
+        parsed_values = @parser.parse(response)
+        nil
+      end
+      error ||= @validator.call(parsed_values)
       ValidatedResponse.new(response, parsed_values:, error:, response_definition: self)
     end
 

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -38,9 +38,9 @@ module OpenapiFirst
     # Print the coverage report
     # @param formatter A formatter to define the report.
     # @output [IO] An output where to puts the report.
-    def self.report_coverage(formatter: Coverage::TerminalFormatter)
+    def self.report_coverage(formatter: Coverage::TerminalFormatter, **)
       coverage_result = Coverage.result
-      puts formatter.new.format(coverage_result)
+      puts formatter.new(**).format(coverage_result)
       puts "The overal API validation coverage of this run is: #{coverage_result.coverage}%"
     end
 

--- a/lib/openapi_first/test/coverage/terminal_formatter.rb
+++ b/lib/openapi_first/test/coverage/terminal_formatter.rb
@@ -5,6 +5,10 @@ module OpenapiFirst
     module Coverage
       # This is the default formatter
       class TerminalFormatter
+        def initialize(verbose: false)
+          @verbose = verbose
+        end
+
         # This takes a list of Coverage::Plan instances and outputs a String
         def format(coverage_result)
           @out = StringIO.new
@@ -12,7 +16,7 @@ module OpenapiFirst
           @out.string
         end
 
-        private attr_reader :out
+        private attr_reader :out, :verbose
 
         private
 
@@ -27,10 +31,10 @@ module OpenapiFirst
         def format_plan(plan)
           filepath = plan.filepath
           puts ['', "API validation coverage for #{filepath}: #{plan.coverage}%"]
-          return if plan.done?
+          return if plan.done? && !verbose
 
           plan.routes.each do |route|
-            next if route.finished?
+            next if route.finished? && !verbose
 
             format_requests(route.requests)
             next if route.requests.none?(&:requested?)
@@ -52,7 +56,7 @@ module OpenapiFirst
         def format_responses(responses)
           responses.each do |response|
             if response.finished?
-              puts green "  ✓  #{response_label(response)}"
+              puts green "  ✓  #{response_label(response)}" if verbose
             else
               puts red "  ❌ #{response_label(response)} – #{explain_unfinished_response(response)}"
             end

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '2.3.0'
+  VERSION = '2.4.0'
 end

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
     it 'raises an error' do
       expect do
         get '/pets'
-      end.to throw_symbol(OpenapiFirst::FAILURE)
+      end.to raise_error OpenapiFirst::ResponseInvalidError
     end
   end
 

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe OpenapiFirst::Test do
       expect(described_class.definitions[:default].filepath).to eq(OpenapiFirst.load('./examples/openapi.yaml').filepath)
     end
 
+    it 'sets up minimum_coverage' do
+      described_class.setup do |test|
+        test.register('./examples/openapi.yaml')
+        test.minimum_coverage = 100
+      end
+      expect(described_class.definitions[:default].filepath).to eq(OpenapiFirst.load('./examples/openapi.yaml').filepath)
+    end
+
     it 'raises an error if no block is given' do
       expect do
         described_class.setup
@@ -57,10 +65,14 @@ RSpec.describe OpenapiFirst::Test do
   end
 
   describe '.report_coverage' do
+    let(:output) { StringIO.new }
+
     before do
       described_class.setup do |test|
         test.register('./spec/data/dice.yaml')
       end
+
+      allow($stdout).to receive(:puts).and_invoke(output.method(:puts))
     end
 
     it 'reports 50% if halfe of requests/responses have been tracked' do
@@ -69,8 +81,6 @@ RSpec.describe OpenapiFirst::Test do
       definition.validate_request(valid_request, raise_error: true)
       # Response not tracked
 
-      output = StringIO.new
-      allow($stdout).to receive(:puts).and_invoke(output.method(:puts))
       described_class.report_coverage
       expect(output.string).to include('The overal API validation coverage of this run is: 50%')
     end
@@ -84,8 +94,6 @@ RSpec.describe OpenapiFirst::Test do
       response.content_type = 'application/json'
       definition.validate_response(valid_request, response, raise_error: true)
 
-      output = StringIO.new
-      allow($stdout).to receive(:puts).and_invoke(output.method(:puts))
       described_class.report_coverage
       expect(output.string).to include('The overal API validation coverage of this run is: 100%')
     end
@@ -100,8 +108,6 @@ RSpec.describe OpenapiFirst::Test do
         response.content_type = 'application/json'
         definition.validate_response(valid_request, response, raise_error: true)
 
-        output = StringIO.new
-        allow($stdout).to receive(:puts).and_invoke(output.method(:puts))
         described_class.report_coverage(verbose: true)
 
         expected_output = [


### PR DESCRIPTION
- Support less verbose test setup without the need to call `OpenapiFirst::Test.report_coverage`, which will be called `at_exit`:
  ```ruby
  OpenapiFirst::Test.setup do |test|
    test.register('openapi/openapi.yaml')
    test.minimum_coverage = 100 # Setting this will lead to an `exit 2` if coverage is below minimum
  end
  ```
- Add `OpenapiFirst::Test::Setup#minimum_coverage=` to control exit behaviour (exit 2 if coverage is below minimum)
- Add `verbose` option to `OpenapiFirst::Test.report_coverage(verbose: true)`
  to see all passing requests/responses