### PR TITLE
Add option to skip certain responses in coverage calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - OpenapiFirst::Test.report_coverage now includes fractional digits when returning a coverage value to avoid reporting "0% / no requests made" even though some requests have been made.
+- Add option to skip certain responses in coverage calculation
 
 ## 2.4.0
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,10 @@ Here is how to set it up for RSpec in your `spec/spec_helper.rb`:
 1. Register all OpenAPI documents to track coverage for and start tracking. This should go at the top of you test helper file before loading application code.
   ```ruby
   require 'openapi_first'
-  OpenapiFirst::Test.setup do |test|
+  OpenapiFirst::Test.setup do |s|
     test.register('openapi/openapi.yaml')
     test.minimum_coverage = 100 # Setting this will lead to an `exit 2` if coverage is below minimum
+    test.skip_response_coverage { it.status == '500' }
   end
   ```
 2. Wrap your app with silent request / response validation. This validates all requets/responses you do during your test run. (✷1)

--- a/examples/openapi.yaml
+++ b/examples/openapi.yaml
@@ -26,3 +26,5 @@ paths:
                 properties:
                   hello:
                     type: string
+        "401":
+          description: Unauthorized

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -18,6 +18,7 @@ module OpenapiFirst
         @minimum_coverage = 0
         @coverage_formatter = Coverage::TerminalFormatter
         @coverage_formatter_options = {}
+        @skip_response_coverage = nil
         yield self
       end
 
@@ -25,9 +26,13 @@ module OpenapiFirst
         Test.register(*)
       end
 
-      def skip_response_coverage_for_status(*statuses); end
-
       attr_accessor :minimum_coverage, :coverage_formatter_options, :coverage_formatter
+
+      def skip_response_coverage(&block)
+        return @skip_response_coverage unless block_given?
+
+        @skip_response_coverage = block
+      end
 
       # This called at_exit
       def handle_exit
@@ -54,8 +59,9 @@ module OpenapiFirst
         raise ArgumentError, "Please provide a block to #{self.class}.setup to register you API descriptions"
       end
 
-      Coverage.start
+      Coverage.install
       setup = Setup.new(&)
+      Coverage.start(skip_response: setup.skip_response_coverage)
 
       if definitions.empty?
         raise NotRegisteredError,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,8 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.after do
+  config.after(:each) do
     OpenapiFirst::Test.definitions.clear
+    OpenapiFirst::Test::Coverage.uninstall
   end
 end

--- a/spec/test/coverage/plan_spec.rb
+++ b/spec/test/coverage/plan_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe OpenapiFirst::Test::Coverage::Plan do
     oad.validate_response(request, response)
   end
 
-  subject(:plan) { described_class.new(oad) }
+  subject(:plan) { described_class.for(oad) }
 
   it 'tracks requests and responses' do
     request = plan.routes.first.requests.first
@@ -136,5 +136,21 @@ RSpec.describe OpenapiFirst::Test::Coverage::Plan do
     expect(plan.tasks[0].path).to eq('/stuff/{id}')
     expect(plan.tasks[1].status).to eq('200')
     expect(plan.tasks[2].status).to eq('4XX')
+  end
+
+  context 'with skip_response option' do
+    let(:plan) do
+      skip_response = ->(response) { response.status == '4XX' }
+      described_class.for(oad, skip_response:)
+    end
+
+    it 'can be done without the skipped response' do
+      expect(plan).not_to be_done
+
+      plan.track_request(valid_request)
+      plan.track_response(valid_response)
+
+      expect(plan.coverage).to eq(100)
+    end
   end
 end

--- a/spec/test/coverage_spec.rb
+++ b/spec/test/coverage_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe OpenapiFirst::Test::Coverage do
   let(:definition) { OpenapiFirst.load(filepath) }
 
   before(:each) do
+    described_class.install
     OpenapiFirst::Test.register(filepath)
     described_class.start
   end
 
   after(:each) do
-    described_class.stop
+    described_class.uninstall
     described_class.reset
   end
 
@@ -22,17 +23,21 @@ RSpec.describe OpenapiFirst::Test::Coverage do
 
   let(:result) { described_class.result }
 
-  describe '.start' do
-    after { described_class.stop }
-
+  describe '.install' do
     it 'installs global hooks' do
+      described_class.install
+
       hooks = OpenapiFirst.configuration.hooks
-      described_class.stop
-      expect(hooks[:after_request_validation]).to be_empty
-      expect(hooks[:after_response_validation]).to be_empty
-      described_class.start
       expect(hooks[:after_request_validation]).not_to be_empty
       expect(hooks[:after_response_validation]).not_to be_empty
+    end
+
+    it 'does not install hooks multiple times' do
+      2.times { described_class.install }
+
+      hooks = OpenapiFirst.configuration.hooks
+      expect(hooks[:after_request_validation].count).to eq(1)
+      expect(hooks[:after_response_validation].count).to eq(1)
     end
   end
 

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -5,7 +5,7 @@ require 'minitest'
 RSpec.describe OpenapiFirst::Test do
   after(:each) do
     described_class.definitions.clear
-    OpenapiFirst::Test::Coverage.stop
+    OpenapiFirst::Test::Coverage.uninstall
     OpenapiFirst::Test::Coverage.reset
   end
 
@@ -49,6 +49,14 @@ RSpec.describe OpenapiFirst::Test do
         test.minimum_coverage = 100
       end
       expect(described_class.definitions[:default].filepath).to eq(OpenapiFirst.load('./examples/openapi.yaml').filepath)
+    end
+
+    it 'can skip responses for coverage' do
+      described_class.setup do |test|
+        test.register('./examples/openapi.yaml')
+        test.skip_response_coverage { |res| res.status == '401' }
+      end
+      expect(described_class::Coverage.plans.first.tasks.count).to eq(2)
     end
 
     it 'raises an error if no block is given' do


### PR DESCRIPTION
```ruby
  OpenapiFirst::Test.setup do |s|
    test.register('openapi/openapi.yaml')
    test.skip_response_coverage { it.status == '401' }
  end
```