### PR TITLE
2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.6.0
+
 - Middlewares now accept the OAD as a first positional argument instead of `:spec` inside the options hash.
 - No longer merge parameter schemas of the same location (for example "query") in order to fix [#320](https://github.com/ahx/openapi_first/issues/320). Use `OpenapiFirst::Schema::Hash` to validate multiple parameters schemas and return a single error object.
 - `OpenapiFirst::Test::Methods[MyApplication]` returns a Module which adds an `app` method to be used by rack-test alonside the `assert_api_conform` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Middlewares now accept the OAD as a first positional argument instead of `:spec` inside the options hash.
-- No longer merge parameter schemas per of the same location (for example "query") in order to fix https://github.com/ahx/openapi_first/issues/320
+- No longer merge parameter schemas of the same location (for example "query") in order to fix [#320](https://github.com/ahx/openapi_first/issues/320). Use `OpenapiFirst::Schema::Hash` to validate multiple parameters schemas and return a single error object.
 - `OpenapiFirst::Test::Methods[MyApplication]` returns a Module which adds an `app` method to be used by rack-test alonside the `assert_api_conform` method.
 - Make default coverage report less verbose
   The default formatter (TerminalFormatter) no longer prints all un-requested requests by default. You can set `test.coverage_formatter_options = { focused: false }` to get back the old behavior

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (2.5.1)
+    openapi_first (2.6.0)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.3.3, < 2.0)
@@ -71,7 +71,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.6-x86_64-linux-gnu)
       racc (~> 1.4)
-    openapi_parameters (0.4.0)
+    openapi_parameters (0.5.0)
       rack (>= 2.2)
     parallel (1.26.3)
     parser (3.3.7.2)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (2.5.1)
+    openapi_first (2.6.0)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.3.3, < 2.0)
@@ -15,7 +15,7 @@ GEM
     benchmark-memory (0.2.0)
       memory_profiler (~> 1)
     bigdecimal (3.1.9)
-    committee (5.5.1)
+    committee (5.5.2)
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (~> 2.0)
       rack (>= 1.5, < 3.2)
@@ -26,12 +26,12 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
-    logger (1.6.6)
+    logger (1.7.0)
     memory_profiler (1.1.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.4)
-    openapi_parameters (0.4.0)
+    openapi_parameters (0.5.0)
       rack (>= 2.2)
     openapi_parser (2.2.4)
     optparse (0.6.0)
@@ -59,7 +59,7 @@ GEM
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     tilt (2.6.0)
-    vernier (1.6.0)
+    vernier (1.7.0)
     webrick (1.9.1)
 
 PLATFORMS

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '2.5.1'
+  VERSION = '2.6.0'
 end

--- a/spec/middlewares/request_validation_spec.rb
+++ b/spec/middlewares/request_validation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
   let(:app) do
     Rack::Builder.app do
       use Rack::Lint
-      use(OpenapiFirst::Middlewares::RequestValidation, spec: File.expand_path('../data/petstore.yaml', __dir__))
+      use(OpenapiFirst::Middlewares::RequestValidation, File.expand_path('../data/petstore.yaml', __dir__))
       use Rack::Lint
       run lambda { |_env|
         Rack::Response.new('hello', 200).finish
@@ -32,10 +32,10 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
     end
   end
 
-  context 'when OAD is passed as first argument' do
+  context 'when OAD is passed as spec: argument' do
     let(:app) do
       Rack::Builder.app do
-        use(OpenapiFirst::Middlewares::RequestValidation, File.expand_path('../data/petstore-expanded.yaml', __dir__))
+        use(OpenapiFirst::Middlewares::RequestValidation, spec: File.expand_path('../data/petstore-expanded.yaml', __dir__))
         run ->(_) {}
       end
     end
@@ -60,7 +60,7 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
     let(:app) do
       Rack::Builder.app do
         use(OpenapiFirst::Middlewares::RequestValidation,
-            spec: File.expand_path('../data/petstore-expanded.yaml', __dir__))
+            File.expand_path('../data/petstore-expanded.yaml', __dir__))
         run ->(_) {}
       end
     end
@@ -92,8 +92,8 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
   context 'with error_response: :default' do
     let(:app) do
       Rack::Builder.app do
-        use OpenapiFirst::Middlewares::RequestValidation, spec: './spec/data/request-body-validation.yaml',
-                                                          error_response: :default
+        use OpenapiFirst::Middlewares::RequestValidation, './spec/data/request-body-validation.yaml',
+            error_response: :default
         run ->(_) {}
       end
     end
@@ -115,8 +115,8 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
         def status = 409
       end
       Rack::Builder.app do
-        use OpenapiFirst::Middlewares::RequestValidation, spec: './spec/data/request-body-validation.yaml',
-                                                          error_response: custom_class
+        use OpenapiFirst::Middlewares::RequestValidation, './spec/data/request-body-validation.yaml',
+            error_response: custom_class
         run ->(_) {}
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
     let(:app) do
       Rack::Builder.app do
         use(OpenapiFirst::Middlewares::RequestValidation,
-            spec: File.expand_path('../data/discriminator-refs.yaml', __dir__))
+            File.expand_path('../data/discriminator-refs.yaml', __dir__))
         run lambda { |_env|
           Rack::Response.new('hello', 200).finish
         }
@@ -178,8 +178,8 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
         end
       end
       Rack::Builder.app do
-        use OpenapiFirst::Middlewares::RequestValidation, spec:,
-                                                          error_response: false
+        use OpenapiFirst::Middlewares::RequestValidation, spec,
+            error_response: false
         run lambda { |_env|
           Rack::Response.new('hello', 200).finish
         }
@@ -197,8 +197,8 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
   context 'with error_response: nil' do
     let(:app) do
       Rack::Builder.app do
-        use OpenapiFirst::Middlewares::RequestValidation, spec: './spec/data/request-body-validation.yaml',
-                                                          error_response: nil
+        use OpenapiFirst::Middlewares::RequestValidation, './spec/data/request-body-validation.yaml',
+            error_response: nil
         run ->(_) {}
       end
     end
@@ -214,7 +214,7 @@ RSpec.describe OpenapiFirst::Middlewares::RequestValidation do
   describe '#app' do
     it 'returns the next app in the stack' do
       app = double
-      expect(described_class.new(app, spec: File.expand_path('../data/petstore.yaml', __dir__)).app).to eq app
+      expect(described_class.new(app, File.expand_path('../data/petstore.yaml', __dir__)).app).to eq app
     end
   end
 end

--- a/spec/middlewares/response_validation_spec.rb
+++ b/spec/middlewares/response_validation_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
   end
   let(:response) { Rack::Response.new(response_body, status, headers) }
 
-  context 'with path to OAD as first argument' do
+  context 'with path to OAD as spec: argument' do
     let(:response_body) { '2' }
 
     let(:app) do
@@ -33,7 +33,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
       definition = spec
       Rack::Builder.app do
         use Rack::Lint
-        use OpenapiFirst::Middlewares::ResponseValidation, definition
+        use OpenapiFirst::Middlewares::ResponseValidation, spec: definition
         run ->(_env) { res.finish }
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
         res = response
         definition = spec
         Rack::Builder.app do
-          use OpenapiFirst::Middlewares::ResponseValidation, spec: definition
+          use OpenapiFirst::Middlewares::ResponseValidation, definition
           run ->(_env) { res.finish }
         end
       end
@@ -255,7 +255,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
   context 'when response is invalid' do
     let(:app) do
       Rack::Builder.new.tap do |builder|
-        builder.use(described_class, spec: './spec/data/petstore.yaml')
+        builder.use(described_class, './spec/data/petstore.yaml')
         builder.run lambda { |_env|
           Rack::Response.new('{"foo": "bar"}', 200, { 'Content-Type' => 'application/json' }).finish
         }
@@ -271,7 +271,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
     context 'with raise_error: false' do
       let(:app) do
         Rack::Builder.new.tap do |builder|
-          builder.use(described_class, spec: './spec/data/petstore.yaml', raise_error: false)
+          builder.use(described_class, './spec/data/petstore.yaml', raise_error: false)
           builder.run lambda { |_env|
             Rack::Response.new('{"foo": "bar"}', 200, { 'Content-Type' => 'application/json' }).finish
           }
@@ -289,7 +289,7 @@ RSpec.describe OpenapiFirst::Middlewares::ResponseValidation do
   context 'when response is not valid JSON' do
     let(:app) do
       Rack::Builder.new.tap do |builder|
-        builder.use(described_class, spec: './spec/data/petstore.yaml')
+        builder.use(described_class, './spec/data/petstore.yaml')
         builder.run lambda { |_env|
           Rack::Response.new('{boofar}', 200, { 'Content-Type' => 'application/json' }).finish
         }


### PR DESCRIPTION
- Middlewares now accept the OAD as a first positional argument instead of `:spec` inside the options hash.
- No longer merge parameter schemas of the same location (for example "query") in order to fix [#320](https://github.com/ahx/openapi_first/issues/320). Use `OpenapiFirst::Schema::Hash` to validate multiple parameters schemas and return a single error object.
- `OpenapiFirst::Test::Methods[MyApplication]` returns a Module which adds an `app` method to be used by rack-test alonside the `assert_api_conform` method.
- Make default coverage report less verbose
  The default formatter (TerminalFormatter) no longer prints all un-requested requests by default. You can set `test.coverage_formatter_options = { focused: false }` to get back the old behavior