### PR TITLE
Allow to override path for schema matching with `env[OpenapiFirst::PATH]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow to override path for schema matching with `env[OpenapiFirst::PATH]` (https://github.com/ahx/openapi_first/pull/345)
+
 ## 2.6.0
 
 - Middlewares now accept the OAD as a first positional argument instead of `:spec` inside the options hash.

--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -15,6 +15,10 @@ module OpenapiFirst
 
   # Key in rack to find instance of Request
   REQUEST = 'openapi.request'
+
+  # Key in rack env that stores the alternative path used for schema matching
+  RACK_KEY_PATH_TO_MATCH = 'openapi.path_to_match'
+
   FAILURE = :openapi_first_validation_failure
 
   # @return [Configuration]
@@ -30,6 +34,13 @@ module OpenapiFirst
 
   ERROR_RESPONSES = {} # rubocop:disable Style/MutableConstant
   private_constant :ERROR_RESPONSES
+
+  # Retrieve the path used for schema matching.
+  #
+  # @param [Rack::Request] rack_request
+  def self.get_path_to_match(rack_request)
+    rack_request.env[RACK_KEY_PATH_TO_MATCH] || rack_request.path
+  end
 
   # Register an error response class
   # @param name [Symbol]

--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -35,13 +35,6 @@ module OpenapiFirst
   ERROR_RESPONSES = {} # rubocop:disable Style/MutableConstant
   private_constant :ERROR_RESPONSES
 
-  # Retrieve the path used for schema matching.
-  #
-  # @param [Rack::Request] rack_request
-  def self.get_path_to_match(rack_request)
-    rack_request.env[PATH] || rack_request.path
-  end
-
   # Register an error response class
   # @param name [Symbol]
   # @param klass [Class] A class that includes / implements OpenapiFirst::ErrorResponse

--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -16,8 +16,8 @@ module OpenapiFirst
   # Key in rack to find instance of Request
   REQUEST = 'openapi.request'
 
-  # Key in rack env that stores the alternative path used for schema matching
-  RACK_KEY_PATH_TO_MATCH = 'openapi.path_to_match'
+  # Key in rack to store the alternate path used for schema matching
+  PATH = 'openapi.path'
 
   FAILURE = :openapi_first_validation_failure
 
@@ -39,7 +39,7 @@ module OpenapiFirst
   #
   # @param [Rack::Request] rack_request
   def self.get_path_to_match(rack_request)
-    rack_request.env[RACK_KEY_PATH_TO_MATCH] || rack_request.path
+    rack_request.env[PATH] || rack_request.path
   end
 
   # Register an error response class

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -62,7 +62,8 @@ module OpenapiFirst
     # @param raise_error [Boolean] Whethir to raise an error if validation fails.
     # @return [ValidatedResponse] The validated response object.
     def validate_response(rack_request, rack_response, raise_error: false)
-      route = @router.match(rack_request.request_method, resolve_path(rack_request), content_type: rack_request.content_type)
+      route = @router.match(rack_request.request_method, resolve_path(rack_request),
+                            content_type: rack_request.content_type)
       return if route.error # Skip response validation for unknown requests
 
       response_match = route.match_response(status: rack_response.status, content_type: rack_response.content_type)

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -45,7 +45,7 @@ module OpenapiFirst
     # @param [Boolean] raise_error Whether to raise an error if validation fails.
     # @return [ValidatedRequest] The validated request object.
     def validate_request(request, raise_error: false)
-      route = @router.match(request.request_method, OpenapiFirst.get_path_to_match(request), content_type: request.content_type)
+      route = @router.match(request.request_method, resolve_path(request), content_type: request.content_type)
       if route.error
         ValidatedRequest.new(request, error: route.error)
       else
@@ -62,7 +62,7 @@ module OpenapiFirst
     # @param raise_error [Boolean] Whethir to raise an error if validation fails.
     # @return [ValidatedResponse] The validated response object.
     def validate_response(rack_request, rack_response, raise_error: false)
-      route = @router.match(rack_request.request_method, OpenapiFirst.get_path_to_match(rack_request), content_type: rack_request.content_type)
+      route = @router.match(rack_request.request_method, resolve_path(rack_request), content_type: rack_request.content_type)
       return if route.error # Skip response validation for unknown requests
 
       response_match = route.match_response(status: rack_response.status, content_type: rack_response.content_type)
@@ -75,6 +75,12 @@ module OpenapiFirst
         @config.hooks[:after_response_validation]&.each { |hook| hook.call(validated, rack_request, self) }
         raise validated.error.exception(validated) if raise_error && validated.invalid?
       end
+    end
+
+    private
+
+    def resolve_path(rack_request)
+      rack_request.env[PATH] || rack_request.path
     end
   end
 end

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -45,7 +45,7 @@ module OpenapiFirst
     # @param [Boolean] raise_error Whether to raise an error if validation fails.
     # @return [ValidatedRequest] The validated request object.
     def validate_request(request, raise_error: false)
-      route = @router.match(request.request_method, request.path, content_type: request.content_type)
+      route = @router.match(request.request_method, OpenapiFirst.get_path_to_match(request), content_type: request.content_type)
       if route.error
         ValidatedRequest.new(request, error: route.error)
       else
@@ -62,7 +62,7 @@ module OpenapiFirst
     # @param raise_error [Boolean] Whethir to raise an error if validation fails.
     # @return [ValidatedResponse] The validated response object.
     def validate_response(rack_request, rack_response, raise_error: false)
-      route = @router.match(rack_request.request_method, rack_request.path, content_type: rack_request.content_type)
+      route = @router.match(rack_request.request_method, OpenapiFirst.get_path_to_match(rack_request), content_type: rack_request.content_type)
       return if route.error # Skip response validation for unknown requests
 
       response_match = route.match_response(status: rack_response.status, content_type: rack_response.content_type)

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -215,11 +215,11 @@ RSpec.describe OpenapiFirst::Definition do
     end
 
     context 'with an alternate path used for schema matching' do
-      let(:request) {
-        build_request('/prefix/stuff/42').tap { |req|
+      let(:request) do
+        build_request('/prefix/stuff/42').tap do |req|
           req.env[OpenapiFirst::PATH] = '/stuff/42'
-        }
-      }
+        end
+      end
 
       it 'returns a valid request' do
         validated = definition.validate_request(request)
@@ -312,11 +312,11 @@ RSpec.describe OpenapiFirst::Definition do
     end
 
     context 'with an alternate path used for schema matching' do
-      let(:request) {
-        build_request('/prefix/stuff/42').tap { |req|
+      let(:request) do
+        build_request('/prefix/stuff/42').tap do |req|
           req.env[OpenapiFirst::PATH] = '/stuff'
-        }
-      }
+        end
+      end
       let(:response) { Rack::Response.new(JSON.generate({ 'id' => 42 }), 200, { 'Content-Type' => 'application/json' }) }
 
       it 'returns a valid response' do

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -213,6 +213,20 @@ RSpec.describe OpenapiFirst::Definition do
         ).to be_valid
       end
     end
+
+    context 'with an alternate path used for schema matching' do
+      let(:request) {
+        build_request('/prefix/stuff/42').tap { |req|
+          req.env[OpenapiFirst::RACK_KEY_PATH_TO_MATCH] = '/stuff/42'
+        }
+      }
+
+      it 'returns a valid request' do
+        validated = definition.validate_request(request)
+        expect(validated).to be_valid
+        expect(validated.parsed_path_parameters).to eq({ 'id' => 42 })
+      end
+    end
   end
 
   describe '#validate_response' do
@@ -294,6 +308,21 @@ RSpec.describe OpenapiFirst::Definition do
           expect(error.response).to be_a(OpenapiFirst::ValidatedResponse)
           expect(error.response.content_type).to eq(response.content_type)
         end
+      end
+    end
+
+    context 'with an alternate path used for schema matching' do
+      let(:request) {
+        build_request('/prefix/stuff/42').tap { |req|
+          req.env[OpenapiFirst::RACK_KEY_PATH_TO_MATCH] = '/stuff'
+        }
+      }
+      let(:response) { Rack::Response.new(JSON.generate({ 'id' => 42 }), 200, { 'Content-Type' => 'application/json' }) }
+
+      it 'returns a valid response' do
+        validated = definition.validate_response(request, response)
+        expect(validated).to be_valid
+        expect(validated.parsed_body).to eq({ 'id' => 42 })
       end
     end
   end

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe OpenapiFirst::Definition do
     context 'with an alternate path used for schema matching' do
       let(:request) {
         build_request('/prefix/stuff/42').tap { |req|
-          req.env[OpenapiFirst::RACK_KEY_PATH_TO_MATCH] = '/stuff/42'
+          req.env[OpenapiFirst::PATH] = '/stuff/42'
         }
       }
 
@@ -314,7 +314,7 @@ RSpec.describe OpenapiFirst::Definition do
     context 'with an alternate path used for schema matching' do
       let(:request) {
         build_request('/prefix/stuff/42').tap { |req|
-          req.env[OpenapiFirst::RACK_KEY_PATH_TO_MATCH] = '/stuff'
+          req.env[OpenapiFirst::PATH] = '/stuff'
         }
       }
       let(:response) { Rack::Response.new(JSON.generate({ 'id' => 42 }), 200, { 'Content-Type' => 'application/json' }) }


### PR DESCRIPTION
# Task

- [x] Impl
- [x] Fix RuboCop offenses
- [x] Pass CI
- ~~Add the usage to README~~ -> in separate PR

# Summary

This is the equivalent to the `prefix` option in the committee gem. It allows developers to modify the request path used for schema matching as shown below:

```rb
# in rails-app/config/application.rb
    ::CleanPathToMatchOpenAPISchema = Class.new {
      def initialize(app)
        @app = app
      end

      def call(env)
        request = Rack::Request.new(env)
        env[OpenapiFirst::RACK_KEY_PATH_TO_MATCH] = request.path.to_s.sub(%r"^/prefix", "")
        @app.call(env)
      end
    }
    config.middleware.use(::CleanPathToMatchOpenAPISchema)
    config.middleware.use OpenapiFirst::Middlewares::RequestValidation, ...
```

p.s.

Thank you for creating such a nice gem as an alternative to committee. I switched from committee to this. Thanks to openapi_first, my headache with query parameters using brackets (`array[]`) has gone away.

