### PR TITLE
Make OpenapiFirst::Test more strict and more configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 OpenapiFirst::Test is stricter and more configurable:
-- Added `OpenapiFirst::Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
+- Added `Test.setup { it.observe }` and low level `Test::Callable[]` to inject request/response validation in rack app as an alternative to overwrite the `app` method in a test
+- Added `Test.observe(App, api: :my_api)`
+- Added Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
 - Changed `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage` or deactivate coverage with `report_coverage = false` or `report_coverage = :warn`
 - Added `OpenapiFirst::Test::Configuration#report_coverage=` to configure the behavior if not all requests/responses of the API under test have been tested.
 - Deprecated `OpenapiFirst::Test::Configuration#minimum_coverage=` use "#report_coverage=true/false/:info" instead to modify the behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- OpenapiFirst::Test now raises an "invalid response" error if it sees an invalid response.
+  You can change this back to the old behavior by setting `response_raise_error = false`:
+  ```ruby
+  OpenapiFirst::Test.setup do |test|
+    # test.register(...)
+    test.response_raise_error = false
+  end
+  ```
+
 ## 2.7.4
 
 - Return 400 if Rack cannot parse query string instead of raising an exception. Fixes https://github.com/ahx/openapi_first/issues/372

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ OpenapiFirst::Test is stricter and more configurable:
 - Added Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
 - Changed `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage` or deactivate coverage with `report_coverage = false` or `report_coverage = :warn`
 - Added `OpenapiFirst::Test::Configuration#report_coverage=` to configure the behavior if not all requests/responses of the API under test have been tested.
-- Deprecated `OpenapiFirst::Test::Configuration#minimum_coverage=` use "#report_coverage=true/false/:info" instead to modify the behavior
 - Changed OpenapiFirst::Test to raises an "invalid response" error if it sees an invalid response (https://github.com/ahx/openapi_first/issues/366).
   You can change this back to the old behavior by setting `response_raise_error = false` (but you shouldn't).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 Changes:
 - Changed OpenapiFirst::Test to raises an "invalid response" error if it sees an invalid response (https://github.com/ahx/openapi_first/issues/366).
   You can change this back to the old behavior by setting `OpenapiFirst::Test::Configuration#response_raise_error = false` (but you shouldn't).
-- Added `Test.setup { it.observe(MyApp) }` and internal `Test.observe(App, api: :my_api)`, `Test::Callable[]` to inject request/response validation in rack app as an alternative to overwrite the `app` method in a test
-- Added `Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
+- Added `Test.setup { it.observe(MyApp) }`, `Test.observe(App, api: :my_api)` and internal `Test::Callable[]` to inject request/response validation in rack app as an alternative to overwrite the `app` method in a test
+- Added `Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description. 404 statuses are ignored by default.
 - Changed `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage` or deactivate coverage with `OpenapiFirst::Test::Configuration#report_coverage = false` or `report_coverage = :warn`
 
 ## 2.7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-
+- Change `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage_if` or deactivate coverage with `report_coverage = false` or `report_coverage = :warn`
+- Added `OpenapiFirst::Test::Configuration#report_coverage=` to configure the behavior if not all requests/responses of the API under test have been tested.
+- Deprecate  `OpenapiFirst::Test::Configuration#minimum_coverage=` use "#report_coverage" instead to modify the behavior
 - OpenapiFirst::Test now raises an "invalid response" error if it sees an invalid response.
   You can change this back to the old behavior by setting `response_raise_error = false`:
   ```ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.8.0
+
 ### OpenapiFirst::Test is now stricter and more configurable
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add `OpenapiFirst::Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
 - Change `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage_if` or deactivate coverage with `report_coverage = false` or `report_coverage = :warn`
 - Added `OpenapiFirst::Test::Configuration#report_coverage=` to configure the behavior if not all requests/responses of the API under test have been tested.
 - Deprecate  `OpenapiFirst::Test::Configuration#minimum_coverage=` use "#report_coverage" instead to modify the behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,14 @@
 # Changelog
 
 ## Unreleased
-- Add `OpenapiFirst::Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
-- Change `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage_if` or deactivate coverage with `report_coverage = false` or `report_coverage = :warn`
+
+OpenapiFirst::Test is stricter and more configurable:
+- Added `OpenapiFirst::Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
+- Changed `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage` or deactivate coverage with `report_coverage = false` or `report_coverage = :warn`
 - Added `OpenapiFirst::Test::Configuration#report_coverage=` to configure the behavior if not all requests/responses of the API under test have been tested.
-- Deprecate  `OpenapiFirst::Test::Configuration#minimum_coverage=` use "#report_coverage" instead to modify the behavior
-- OpenapiFirst::Test now raises an "invalid response" error if it sees an invalid response.
-  You can change this back to the old behavior by setting `response_raise_error = false`:
-  ```ruby
-  OpenapiFirst::Test.setup do |test|
-    # test.register(...)
-    test.response_raise_error = false
-  end
-  ```
+- Deprecated `OpenapiFirst::Test::Configuration#minimum_coverage=` use "#report_coverage=true/false/:info" instead to modify the behavior
+- Changed OpenapiFirst::Test to raises an "invalid response" error if it sees an invalid response (https://github.com/ahx/openapi_first/issues/366).
+  You can change this back to the old behavior by setting `response_raise_error = false` (but you shouldn't).
 
 ## 2.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## Unreleased
 
-OpenapiFirst::Test is stricter and more configurable:
-- Added `Test.setup { it.observe }` and low level `Test::Callable[]` to inject request/response validation in rack app as an alternative to overwrite the `app` method in a test
-- Added `Test.observe(App, api: :my_api)`
-- Added Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
-- Changed `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage` or deactivate coverage with `report_coverage = false` or `report_coverage = :warn`
-- Added `OpenapiFirst::Test::Configuration#report_coverage=` to configure the behavior if not all requests/responses of the API under test have been tested.
+### OpenapiFirst::Test is now stricter and more configurable
+
+Changes:
 - Changed OpenapiFirst::Test to raises an "invalid response" error if it sees an invalid response (https://github.com/ahx/openapi_first/issues/366).
-  You can change this back to the old behavior by setting `response_raise_error = false` (but you shouldn't).
+  You can change this back to the old behavior by setting `OpenapiFirst::Test::Configuration#response_raise_error = false` (but you shouldn't).
+- Added `Test.setup { it.observe(MyApp) }` and internal `Test.observe(App, api: :my_api)`, `Test::Callable[]` to inject request/response validation in rack app as an alternative to overwrite the `app` method in a test
+- Added `Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description.
+- Changed `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage` or deactivate coverage with `OpenapiFirst::Test::Configuration#report_coverage = false` or `report_coverage = :warn`
 
 ## 2.7.4
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,11 @@ group :test, :development do
   gem 'bundler'
   gem 'minitest'
   gem 'rack-test'
+  gem 'rails'
   gem 'rake'
   gem 'rspec'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'simplecov'
+  gem 'sinatra'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,26 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (8.0.2)
+      actionpack (= 8.0.2)
+      activesupport (= 8.0.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (8.0.2)
+      actionpack (= 8.0.2)
+      activejob (= 8.0.2)
+      activerecord (= 8.0.2)
+      activestorage (= 8.0.2)
+      activesupport (= 8.0.2)
+      mail (>= 2.8.0)
+    actionmailer (8.0.2)
+      actionpack (= 8.0.2)
+      actionview (= 8.0.2)
+      activejob (= 8.0.2)
+      activesupport (= 8.0.2)
+      mail (>= 2.8.0)
+      rails-dom-testing (~> 2.2)
     actionpack (8.0.2)
       actionview (= 8.0.2)
       activesupport (= 8.0.2)
@@ -20,12 +40,34 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
+    actiontext (8.0.2)
+      actionpack (= 8.0.2)
+      activerecord (= 8.0.2)
+      activestorage (= 8.0.2)
+      activesupport (= 8.0.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
     actionview (8.0.2)
       activesupport (= 8.0.2)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    activejob (8.0.2)
+      activesupport (= 8.0.2)
+      globalid (>= 0.3.6)
+    activemodel (8.0.2)
+      activesupport (= 8.0.2)
+    activerecord (8.0.2)
+      activemodel (= 8.0.2)
+      activesupport (= 8.0.2)
+      timeout (>= 0.4.0)
+    activestorage (8.0.2)
+      actionpack (= 8.0.2)
+      activejob (= 8.0.2)
+      activerecord (= 8.0.2)
+      activesupport (= 8.0.2)
+      marcel (~> 1.0)
     activesupport (8.0.2)
       base64
       benchmark (>= 0.3)
@@ -47,13 +89,22 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
+    date (3.4.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
+    erb (5.0.1)
     erubi (1.13.1)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
     hana (1.3.7)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.0)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.12.2)
     json_schemer (2.4.0)
       bigdecimal
@@ -66,7 +117,26 @@ GEM
     loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.4)
+    mini_mime (1.1.5)
     minitest (5.25.5)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    net-imap (0.5.9)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nio4r (2.7.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
@@ -77,9 +147,19 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.4.0)
+    psych (5.2.6)
+      date
+      stringio
     racc (1.8.1)
     rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -87,6 +167,20 @@ GEM
       rack (>= 1.3)
     rackup (2.2.1)
       rack (>= 3)
+    rails (8.0.2)
+      actioncable (= 8.0.2)
+      actionmailbox (= 8.0.2)
+      actionmailer (= 8.0.2)
+      actionpack (= 8.0.2)
+      actiontext (= 8.0.2)
+      actionview (= 8.0.2)
+      activejob (= 8.0.2)
+      activemodel (= 8.0.2)
+      activerecord (= 8.0.2)
+      activestorage (= 8.0.2)
+      activesupport (= 8.0.2)
+      bundler (>= 1.15.0)
+      railties (= 8.0.2)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -94,9 +188,24 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (8.0.2)
+      actionpack (= 8.0.2)
+      activesupport (= 8.0.2)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
+    rdoc (6.14.1)
+      erb
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.1)
+      io-console (~> 0.5)
+    roda (3.93.0)
+      rack
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -129,6 +238,7 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -137,6 +247,17 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    stringio (3.1.7)
+    thor (1.3.2)
+    tilt (2.6.0)
+    timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
@@ -144,6 +265,11 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   arm64-darwin-21
@@ -159,11 +285,14 @@ DEPENDENCIES
   rack (>= 3.0.0)
   rack-test
   rackup
+  rails
   rake
+  roda
   rspec
   rubocop
   rubocop-performance
   simplecov
+  sinatra
 
 BUNDLED WITH
    2.3.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (2.7.4)
+    openapi_first (2.8.0)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.5.1, < 2.0)
@@ -204,8 +204,6 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
-    roda (3.93.0)
-      rack
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -287,7 +285,6 @@ DEPENDENCIES
   rackup
   rails
   rake
-  roda
   rspec
   rubocop
   rubocop-performance

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Here is how to set it up:
       # Optional: Make tests fail if coverage is below minimum
       test.minimum_coverage = 100
       # Optional: Skip certain responses, which are described in your API description, but need no test coverage
-      test.skip_response_coverage { it.status == '500' } #
+      test.skip_response_coverage_if { |response_definition| response_definition.status.to_s == '500' }
     end
     ```
 2. Add an `app` method to your tests by including a Module. This `app` method wraps your application with silent request / response validation. This validates all requests/responses in your test run. (✷1)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Here is how to set it up:
     OpenapiFirst::Test.setup do |config|
       config.register('openapi/openapi.yaml')
       # Optional: Skip certain responses, which are described in your API description, but need no test coverage
-      config.skip_response_coverage_if { |response_definition| response_definition.status.to_s == '500' }
+      config.skip_response_coverage { |response_definition| response_definition.status.to_s == '500' }
     end
     ```
 2. Add an `app` method to your tests by including a Module. This `app` method wraps your application with silent request / response validation. This validates all requests/responses in your test run. (✷1)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here is how to set it up:
   This should go at the top of your test helper file before loading your application code.
     ```ruby
     require 'openapi_first'
-    OpenapiFirst::Test.configure do |config|
+    OpenapiFirst::Test.setup do |config|
       config.register('openapi/openapi.yaml')
       # Optional: Make tests fail if coverage is below minimum
       config.minimum_coverage = 100

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Here is how to set it up:
     require 'openapi_first'
     OpenapiFirst::Test.setup do |config|
       config.register('openapi/openapi.yaml')
-      # Optional: Make tests fail if coverage is below minimum
-      config.minimum_coverage = 100
       # Optional: Skip certain responses, which are described in your API description, but need no test coverage
       config.skip_response_coverage_if { |response_definition| response_definition.status.to_s == '500' }
     end

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Here is how to set it up:
   This should go at the top of your test helper file before loading your application code.
     ```ruby
     require 'openapi_first'
-    OpenapiFirst::Test.setup do |test|
-      test.register('openapi/openapi.yaml')
+    OpenapiFirst::Test.configure do |config|
+      config.register('openapi/openapi.yaml')
       # Optional: Make tests fail if coverage is below minimum
-      test.minimum_coverage = 100
+      config.minimum_coverage = 100
       # Optional: Skip certain responses, which are described in your API description, but need no test coverage
-      test.skip_response_coverage_if { |response_definition| response_definition.status.to_s == '500' }
+      config.skip_response_coverage_if { |response_definition| response_definition.status.to_s == '500' }
     end
     ```
 2. Add an `app` method to your tests by including a Module. This `app` method wraps your application with silent request / response validation. This validates all requests/responses in your test run. (✷1)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (2.7.4)
+    openapi_first (2.8.0)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.5.1, < 2.0)
@@ -15,7 +15,7 @@ GEM
     benchmark-ips (2.14.0)
     benchmark-memory (0.2.0)
       memory_profiler (~> 1)
-    bigdecimal (3.2.1)
+    bigdecimal (3.2.2)
     committee (5.5.4)
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (~> 2.0)

--- a/lib/openapi_first/configuration.rb
+++ b/lib/openapi_first/configuration.rb
@@ -30,6 +30,7 @@ module OpenapiFirst
     HOOKS.each do |hook|
       define_method(hook) do |&block|
         hooks[hook] << block
+        block
       end
     end
 

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -86,14 +86,15 @@ module OpenapiFirst
 
       response_match = route.match_response(status: rack_response.status, content_type: rack_response.content_type)
       error = response_match.error
-      if error
-        ValidatedResponse.new(rack_response, error:)
-      else
-        response_match.response.validate(rack_response)
-      end.tap do |validated|
-        @config.hooks[:after_response_validation]&.each { |hook| hook.call(validated, rack_request, self) }
-        raise validated.error.exception(validated) if raise_error && validated.invalid?
-      end
+      validated = if error
+                    ValidatedResponse.new(rack_response, error:)
+                  else
+                    response_match.response.validate(rack_response)
+                  end
+      @config.hooks[:after_response_validation]&.each { |hook| hook.call(validated, rack_request, self) }
+      raise validated.error.exception(validated) if raise_error && validated.invalid?
+
+      validated
     end
 
     private

--- a/lib/openapi_first/response_body_parsers.rb
+++ b/lib/openapi_first/response_body_parsers.rb
@@ -23,7 +23,9 @@ module OpenapiFirst
     register(/json/i, lambda do |body|
       JSON.parse(body)
     rescue JSON::ParserError
-      Failure.fail!(:invalid_response_body, message: 'Response body is invalid: Failed to parse response body as JSON')
+      return Failure.fail!(:invalid_response_body, message: 'JSON response body must not be empty') if body.empty?
+
+      Failure.fail!(:invalid_response_body, message: 'Failed to parse response body as JSON')
     end)
   end
 end

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -9,18 +9,14 @@ module OpenapiFirst
     autoload :Coverage, 'openapi_first/test/coverage'
     autoload :Methods, 'openapi_first/test/methods'
     autoload :Callable, 'openapi_first/test/callable'
+    autoload :Observe, 'openapi_first/test/observe'
     extend Registry
 
     class CoverageError < Error; end
 
-    # @visible private
-    module Observed; end
-
     # Inject request/response validation in a rack app class
     def self.observe(app, api: :default)
-      mod = Callable[api:]
-      app.prepend(mod) unless app.include?(Observed)
-      app.include(Observed)
+      Observe.observe(app, api:)
     end
 
     def self.minitest?(base)

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -28,11 +28,14 @@ module OpenapiFirst
 
       attr_accessor :minimum_coverage, :coverage_formatter_options, :coverage_formatter
 
-      def skip_response_coverage(&block)
+      def skip_response_coverage_if(&block)
         return @skip_response_coverage unless block_given?
 
         @skip_response_coverage = block
       end
+
+      # TODO: Deprecate skip_response_coverage
+      alias skip_response_coverage skip_response_coverage_if
 
       # This called at_exit
       def handle_exit

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -104,18 +104,14 @@ module OpenapiFirst
         end
 
         @after_response_validation = config.after_response_validation do |validated_response, rack_request, oad|
-          after_response_validation(validated_response, rack_request, oad)
+          if validated_response.invalid? && raise_response_error?(validated_response)
+            raise validated_response.error.exception
+          end
+
+          Coverage.track_response(validated_response, rack_request, oad)
         end
       end
       @installed = true
-    end
-
-    def self.after_response_validation(validated_response, rack_request, oad)
-      if validated_response.invalid? && raise_response_error?(validated_response)
-        raise validated_response.error.exception
-      end
-
-      Coverage.track_response(validated_response, rack_request, oad)
     end
 
     def self.raise_response_error?(validated_response)

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -63,7 +63,9 @@ module OpenapiFirst
 
       return if Coverage.result.coverage >= configuration.minimum_coverage
 
-      raise OpenapiFirst::Test::CoverageError, 'Not all described requests and responses have been tested.'
+      puts 'API Coverage fails with exit 2, because not all described requests and responses have been tested.'
+
+      exit 2
     end
 
     # Print the coverage report

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -13,7 +13,7 @@ module OpenapiFirst
     end
 
     # Helper class to setup tests
-    class Setup
+    class Configuration
       def initialize
         @minimum_coverage = 0
         @coverage_formatter = Coverage::TerminalFormatter
@@ -59,26 +59,29 @@ module OpenapiFirst
 
     # Sets up OpenAPI test coverage and OAD registration.
     # @yieldparam [OpenapiFirst::Test::Setup] setup A setup for configuration
-    def self.setup(&)
+    def self.configure(&)
       unless block_given?
         raise ArgumentError, "Please provide a block to #{self.class}.setup to register you API descriptions"
       end
 
       Coverage.install
-      setup = Setup.new(&)
-      Coverage.start(skip_response: setup.skip_response_coverage)
+      configuration = Configuration.new(&)
+      Coverage.start(skip_response: configuration.skip_response_coverage)
 
       if definitions.empty?
         raise NotRegisteredError,
               'No API descriptions have been registered. ' \
               'Please register your API description via ' \
-              "OpenapiFirst::Test.setup { |test| test.register('myopenapi.yaml') }"
+              "OpenapiFirst::Test.configure { |config| config.register('myopenapi.yaml') }"
       end
 
-      @setup ||= at_exit do
-        setup.handle_exit
+      @configure ||= at_exit do
+        configuration.handle_exit
       end
     end
+
+    # TODO: Deprecate setup
+    alias setup configure
 
     # Print the coverage report
     # @param formatter A formatter to define the report.

--- a/lib/openapi_first/test/callable.rb
+++ b/lib/openapi_first/test/callable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  module Test
+    # Return a Module with a call method that wrapps silent request/response validation to monitor a Rack app
+    # This is used by Openapi::Test.observe
+    module Callable
+      # Returns a Module with a `call(env)` method that wraps super inside silent request/response validation
+      # You can use this like `Application.prepend(OpenapiFirst::Test.app_module)` to monitor your app during testing.
+      def self.[](api: :default)
+        definition = OpenapiFirst::Test[api]
+        Module.new.tap do |mod|
+          mod.define_method(:call) do |env|
+            request = Rack::Request.new(env)
+            definition.validate_request(request, raise_error: false)
+            response = super(env)
+            status, headers, body = response
+            definition.validate_response(request, Rack::Response[status, headers, body], raise_error: false)
+            response
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/callable.rb
+++ b/lib/openapi_first/test/callable.rb
@@ -7,11 +7,11 @@ module OpenapiFirst
     module Callable
       # Returns a Module with a `call(env)` method that wraps super inside silent request/response validation
       # You can use this like `Application.prepend(OpenapiFirst::Test.app_module)` to monitor your app during testing.
-      def self.[](api: :default)
-        definition = OpenapiFirst::Test[api]
+      def self.[](definition)
         Module.new.tap do |mod|
           mod.define_method(:call) do |env|
             request = Rack::Request.new(env)
+
             definition.validate_request(request, raise_error: false)
             response = super(env)
             status, headers, body = response

--- a/lib/openapi_first/test/configuration.rb
+++ b/lib/openapi_first/test/configuration.rb
@@ -28,15 +28,8 @@ module OpenapiFirst
         @apps[api] = app
       end
 
-      attr_accessor :coverage_formatter_options, :coverage_formatter, :response_raise_error
-      attr_reader :registry, :apps, :minimum_coverage, :report_coverage, :ignored_unknown_status
-
-      def minimum_coverage=(value)
-        warn 'Setting OpenapiFirst::Test::Configuration#minimum_coverage= is deprecated ' \
-             'and will be removed in a future version.' \
-             "Use 'report_coverage = true / false / :info' instead."
-        @minimum_coverage = value
-      end
+      attr_accessor :coverage_formatter_options, :coverage_formatter, :response_raise_error, :minimum_coverage
+      attr_reader :registry, :apps, :report_coverage, :ignored_unknown_status
 
       # Configure report coverage
       # @param [Boolean, :warn] value Whether to report coverage or just warn.

--- a/lib/openapi_first/test/configuration.rb
+++ b/lib/openapi_first/test/configuration.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  module Test
+    # Helper class to setup tests
+    class Configuration
+      def initialize
+        @minimum_coverage = 0
+        @coverage_formatter = Coverage::TerminalFormatter
+        @coverage_formatter_options = {}
+        @skip_response_coverage = nil
+        @response_raise_error = true
+        @registry = {}
+        yield self if block_given?
+      end
+
+      # Register OADs, but don't load them just yet
+      def register(oad, as: :default)
+        @registry[as] = oad
+      end
+
+      attr_accessor :minimum_coverage, :coverage_formatter_options, :coverage_formatter, :response_raise_error
+      attr_reader :registry
+
+      def skip_response_coverage_if(&block)
+        return @skip_response_coverage unless block_given?
+
+        @skip_response_coverage = block
+      end
+
+      # TODO: Deprecate skip_response_coverage
+      alias skip_response_coverage skip_response_coverage_if
+
+      # This called at_exit
+      def handle_exit
+        coverage = Coverage.result.coverage
+        # :nocov:
+        puts 'API Coverage did not detect any API requests for the registered API descriptions' if coverage.zero?
+        if coverage.positive?
+          Test.report_coverage(
+            formatter: coverage_formatter,
+            **coverage_formatter_options
+          )
+        end
+        return unless minimum_coverage > coverage
+
+        puts "API Coverage fails with exit 2, because API coverage of #{coverage}% " \
+             "is below minimum of #{minimum_coverage}%!"
+        exit 2
+        # :nocov:
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/configuration.rb
+++ b/lib/openapi_first/test/configuration.rb
@@ -10,7 +10,7 @@ module OpenapiFirst
         @coverage_formatter_options = {}
         @skip_response_coverage = nil
         @response_raise_error = true
-        @ignored_unknown_status = []
+        @ignored_unknown_status = [404]
         @report_coverage = true
         @registry = {}
       end

--- a/lib/openapi_first/test/configuration.rb
+++ b/lib/openapi_first/test/configuration.rb
@@ -39,14 +39,11 @@ module OpenapiFirst
         @report_coverage = value
       end
 
-      def skip_response_coverage_if(&block)
+      def skip_response_coverage(&block)
         return @skip_response_coverage unless block_given?
 
         @skip_response_coverage = block
       end
-
-      # TODO: Deprecate skip_response_coverage
-      alias skip_response_coverage skip_response_coverage_if
     end
   end
 end

--- a/lib/openapi_first/test/configuration.rb
+++ b/lib/openapi_first/test/configuration.rb
@@ -10,6 +10,7 @@ module OpenapiFirst
         @coverage_formatter_options = {}
         @skip_response_coverage = nil
         @response_raise_error = true
+        @ignored_unknown_status = []
         @report_coverage = true
         @registry = {}
       end
@@ -20,7 +21,7 @@ module OpenapiFirst
       end
 
       attr_accessor :coverage_formatter_options, :coverage_formatter, :response_raise_error
-      attr_reader :registry, :minimum_coverage, :report_coverage
+      attr_reader :registry, :minimum_coverage, :report_coverage, :ignored_unknown_status
 
       def minimum_coverage=(value)
         warn 'Setting OpenapiFirst::Test::Configuration#minimum_coverage= is deprecated ' \

--- a/lib/openapi_first/test/configuration.rb
+++ b/lib/openapi_first/test/configuration.rb
@@ -46,23 +46,6 @@ module OpenapiFirst
 
       # TODO: Deprecate skip_response_coverage
       alias skip_response_coverage skip_response_coverage_if
-
-      # This called at_exit
-      def handle_exit
-        return unless report_coverage
-
-        Test.report_coverage(
-          formatter: coverage_formatter,
-          **coverage_formatter_options
-        )
-        coverage = Coverage.result.coverage
-        return if coverage >= minimum_coverage
-
-        return unless report_coverage == true
-
-        warn 'OpenapiFirst::Test failed with exit 2, because not all described requests/responses have been tested.'
-        exit 2
-      end
     end
   end
 end

--- a/lib/openapi_first/test/configuration.rb
+++ b/lib/openapi_first/test/configuration.rb
@@ -13,15 +13,23 @@ module OpenapiFirst
         @ignored_unknown_status = [404]
         @report_coverage = true
         @registry = {}
+        @apps = {}
       end
 
       # Register OADs, but don't load them just yet
+      # @param [OpenapiFirst::OAD] oad The OAD to register
+      # @param [Symbol] as The name to register the OAD under
       def register(oad, as: :default)
         @registry[as] = oad
       end
 
+      # Observe a rack app
+      def observe(app, api: :default)
+        @apps[api] = app
+      end
+
       attr_accessor :coverage_formatter_options, :coverage_formatter, :response_raise_error
-      attr_reader :registry, :minimum_coverage, :report_coverage, :ignored_unknown_status
+      attr_reader :registry, :apps, :minimum_coverage, :report_coverage, :ignored_unknown_status
 
       def minimum_coverage=(value)
         warn 'Setting OpenapiFirst::Test::Configuration#minimum_coverage= is deprecated ' \
@@ -30,6 +38,8 @@ module OpenapiFirst
         @minimum_coverage = value
       end
 
+      # Configure report coverage
+      # @param [Boolean, :warn] value Whether to report coverage or just warn.
       def report_coverage=(value)
         allowed_values = [true, false, :warn]
         unless allowed_values.include?(value)

--- a/lib/openapi_first/test/coverage.rb
+++ b/lib/openapi_first/test/coverage.rb
@@ -12,26 +12,12 @@ module OpenapiFirst
 
       Result = Data.define(:plans, :coverage)
 
+      @current_run = {}
+
       class << self
         attr_reader :current_run
 
-        def install
-          return if @installed
-
-          @after_request_validation = lambda do |validated_request, oad|
-            track_request(validated_request, oad)
-          end
-
-          @after_response_validation = lambda do |validated_response, request, oad|
-            track_response(validated_response, request, oad)
-          end
-
-          OpenapiFirst.configure do |config|
-            config.after_request_validation(&@after_request_validation)
-            config.after_response_validation(&@after_response_validation)
-          end
-          @installed = true
-        end
+        def install = Test.install
 
         def start(skip_response: nil)
           @current_run = Test.definitions.values.to_h do |oad|
@@ -40,16 +26,11 @@ module OpenapiFirst
           end
         end
 
-        def uninstall
-          configuration = OpenapiFirst.configuration
-          configuration.hooks[:after_request_validation].delete(@after_request_validation)
-          configuration.hooks[:after_response_validation].delete(@after_response_validation)
-          @installed = nil
-        end
+        def uninstall = Test.uninstall
 
         # Clear current coverage run
         def reset
-          @current_run = nil
+          @current_run = {}
         end
 
         def track_request(request, oad)
@@ -72,7 +53,7 @@ module OpenapiFirst
         private
 
         def coverage
-          return 0 unless plans
+          return 0 if plans.empty?
 
           plans.sum(&:coverage) / plans.length
         end

--- a/lib/openapi_first/test/coverage.rb
+++ b/lib/openapi_first/test/coverage.rb
@@ -47,7 +47,7 @@ module OpenapiFirst
 
         # Returns all plans (Plan) that were registered for this run
         def plans
-          current_run&.values
+          current_run.values
         end
 
         private

--- a/lib/openapi_first/test/coverage/terminal_formatter.rb
+++ b/lib/openapi_first/test/coverage/terminal_formatter.rb
@@ -13,7 +13,10 @@ module OpenapiFirst
         def format(coverage_result)
           coverage = coverage_result.coverage
           @out = StringIO.new
-          @out.puts 'API Coverage did not detect any API requests for the registered API descriptions' if coverage.zero?
+          if coverage.zero?
+            @out.puts 'API Coverage did not detect any API requests for the registered API descriptions. ' \
+                      'Make sure to observe your application using OpenapiFirst::Test.'
+          end
           coverage_result.plans.each { |plan| format_plan(plan) } if coverage.positive?
           @out.string
         end
@@ -86,7 +89,9 @@ module OpenapiFirst
         def explain_unfinished_request(request)
           return 'No requests tracked!' unless request.requested?
 
-          "All requests invalid! (#{request.last_error_message.inspect})" unless request.any_valid_request?
+          return if request.any_valid_request?
+
+          "All requests invalid! (#{request.last_error_message.inspect})"
         end
 
         def response_label(response)

--- a/lib/openapi_first/test/coverage/terminal_formatter.rb
+++ b/lib/openapi_first/test/coverage/terminal_formatter.rb
@@ -10,10 +10,11 @@ module OpenapiFirst
           @focused = focused && !verbose
         end
 
-        # This takes a list of Coverage::Plan instances and outputs a String
         def format(coverage_result)
+          coverage = coverage_result.coverage
           @out = StringIO.new
-          coverage_result.plans.each { |plan| format_plan(plan) }
+          @out.puts 'API Coverage did not detect any API requests for the registered API descriptions' if coverage.zero?
+          coverage_result.plans.each { |plan| format_plan(plan) } if coverage.positive?
           @out.string
         end
 

--- a/lib/openapi_first/test/observe.rb
+++ b/lib/openapi_first/test/observe.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  module Test
+    class ObserveError < Error; end
+
+    # @visible private
+    module Observed; end
+
+    # Inject silent request/response validation to observe rack apps during testing
+    module Observe
+      def self.observe(app, api: :default)
+        unless app.instance_methods.include?(:call)
+          raise ObserveError, "Don't know how to observe #{app}, because it has no call instance method."
+        end
+
+        return if app.include?(Observed)
+
+        definition = OpenapiFirst::Test[api]
+        mod = OpenapiFirst::Test::Callable[definition]
+        app.prepend(mod)
+        app.include(Observed)
+      end
+    end
+  end
+end

--- a/lib/openapi_first/test/registry.rb
+++ b/lib/openapi_first/test/registry.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  module Test
+    class NotRegisteredError < Error; end
+    class AlreadyRegisteredError < Error; end
+
+    # @visibility private
+    module Registry
+      def definitions
+        @definitions ||= {}
+      end
+
+      # Register an OpenAPI definition for testing
+      # @param path_or_definition [String, Definition] Path to the OpenAPI file or a Definition object
+      # @param as [Symbol] Name to register the API definition as
+      def register(path_or_definition, as: :default)
+        if definitions.key?(as) && as == :default
+          raise(
+            AlreadyRegisteredError,
+            "#{definitions[as].filepath.inspect} is already registered " \
+            "as ':default' so you cannot register #{path_or_definition.inspect} without " \
+            'giving it a custom name. Please call register with a custom key like: ' \
+            "#{name}.register(#{path_or_definition.inspect}, as: :my_other_api)"
+          )
+        end
+
+        definition = OpenapiFirst.load(path_or_definition)
+        definitions[as] = definition
+        definition
+      end
+
+      def [](api)
+        definitions.fetch(api) do
+          option = api == :default ? '' : ", as: #{api.inspect}"
+          raise(NotRegisteredError,
+                "API description '#{api.inspect}' not found." \
+                "Please call #{name}.register('myopenapi.yaml'#{option}) " \
+                'once before running tests.')
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_first/validators/request_body.rb
+++ b/lib/openapi_first/validators/request_body.rb
@@ -11,7 +11,7 @@ module OpenapiFirst
       def call(parsed_request)
         body = parsed_request.body
         if body.nil?
-          Failure.fail!(:invalid_body, message: 'Request body is not defined') if @required
+          Failure.fail!(:invalid_body, message: 'Request body must not be empty') if @required
           return
         end
 

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '2.7.4'
+  VERSION = '2.8.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,6 @@ RSpec.configure do |config|
 
   config.after(:each) do
     OpenapiFirst::Test.definitions.clear
-    OpenapiFirst::Test::Coverage.uninstall
+    OpenapiFirst::Test.uninstall
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,5 +30,6 @@ RSpec.configure do |config|
   config.after(:each) do
     OpenapiFirst::Test.definitions.clear
     OpenapiFirst::Test.uninstall
+    OpenapiFirst::Test::Coverage.reset
   end
 end

--- a/spec/test/configuration_spec.rb
+++ b/spec/test/configuration_spec.rb
@@ -8,4 +8,15 @@ RSpec.describe OpenapiFirst::Test::Configuration do
       configuration.report_coverage = :fatal
     end.to raise_error(ArgumentError)
   end
+
+  describe 'ignored_unknown_status' do
+    it 'has a default value' do
+      expect(configuration.ignored_unknown_status).to eq [404]
+    end
+
+    it 'can be extended' do
+      configuration.ignored_unknown_status << 401
+      expect(configuration.ignored_unknown_status).to eq [404, 401]
+    end
+  end
 end

--- a/spec/test/configuration_spec.rb
+++ b/spec/test/configuration_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::Test::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe '#handle_exit' do
+    it 'reports coverage and fails' do
+      expect(OpenapiFirst::Test).to receive(:report_coverage)
+      expect do
+        configuration.handle_exit
+      end.to raise_error(SystemExit)
+    end
+
+    it 'raises an error with invalid option value' do
+      expect do
+        configuration.report_coverage = :fatal
+      end.to raise_error(ArgumentError)
+    end
+
+    context 'with full coverage' do
+      let(:definition) do
+        OpenapiFirst.parse(YAML.load(%(
+          openapi: 3.1.0
+          info:
+            title: Dice
+            version: 1
+          paths:
+            "/roll":
+              post:
+                responses:
+                  '200':
+                    content:
+                      application/json:
+                        schema:
+                          type: integer
+                          min: 1
+                          max:
+        )))
+      end
+
+      before do
+        valid_request = Rack::Request.new(Rack::MockRequest.env_for('/roll', method: 'POST'))
+        valid_response = Rack::Response[200, { 'content-type' => 'application/json' }, ['1']]
+        OpenapiFirst::Test.setup { |test| test.register(definition) }
+        definition.validate_request(valid_request)
+        definition.validate_response(valid_request, valid_response)
+      end
+
+      it 'reports coverage but does not fail' do
+        expect(OpenapiFirst::Test).to receive(:report_coverage)
+
+        expect do
+          configuration.handle_exit
+        end.not_to raise_error(SystemExit)
+      end
+    end
+
+    context 'with report_coverage = true' do
+      before do
+        configuration.report_coverage = true
+      end
+
+      it 'reports coverage' do
+        expect(OpenapiFirst::Test).to receive(:report_coverage)
+        expect do
+          configuration.handle_exit
+        end.to raise_error(SystemExit)
+      end
+    end
+
+    context 'with report_coverage = false' do
+      before do
+        configuration.report_coverage = false
+      end
+
+      it 'does not report coverage' do
+        expect(OpenapiFirst::Test).not_to receive(:report_coverage)
+
+        configuration.handle_exit
+      end
+    end
+
+    context 'with report_coverage = :warn' do
+      before do
+        configuration.report_coverage = :warn
+      end
+
+      it 'reports coverage, but does not fail' do
+        expect(OpenapiFirst::Test).to receive(:report_coverage)
+
+        configuration.handle_exit
+      end
+    end
+  end
+end

--- a/spec/test/configuration_spec.rb
+++ b/spec/test/configuration_spec.rb
@@ -3,93 +3,9 @@
 RSpec.describe OpenapiFirst::Test::Configuration do
   subject(:configuration) { described_class.new }
 
-  describe '#handle_exit' do
-    it 'reports coverage and fails' do
-      expect(OpenapiFirst::Test).to receive(:report_coverage)
-      expect do
-        configuration.handle_exit
-      end.to raise_error(SystemExit)
-    end
-
-    it 'raises an error with invalid option value' do
-      expect do
-        configuration.report_coverage = :fatal
-      end.to raise_error(ArgumentError)
-    end
-
-    context 'with full coverage' do
-      let(:definition) do
-        OpenapiFirst.parse(YAML.load(%(
-          openapi: 3.1.0
-          info:
-            title: Dice
-            version: 1
-          paths:
-            "/roll":
-              post:
-                responses:
-                  '200':
-                    content:
-                      application/json:
-                        schema:
-                          type: integer
-                          min: 1
-                          max:
-        )))
-      end
-
-      before do
-        valid_request = Rack::Request.new(Rack::MockRequest.env_for('/roll', method: 'POST'))
-        valid_response = Rack::Response[200, { 'content-type' => 'application/json' }, ['1']]
-        OpenapiFirst::Test.setup { |test| test.register(definition) }
-        definition.validate_request(valid_request)
-        definition.validate_response(valid_request, valid_response)
-      end
-
-      it 'reports coverage but does not fail' do
-        expect(OpenapiFirst::Test).to receive(:report_coverage)
-
-        expect do
-          configuration.handle_exit
-        end.not_to raise_error(SystemExit)
-      end
-    end
-
-    context 'with report_coverage = true' do
-      before do
-        configuration.report_coverage = true
-      end
-
-      it 'reports coverage' do
-        expect(OpenapiFirst::Test).to receive(:report_coverage)
-        expect do
-          configuration.handle_exit
-        end.to raise_error(SystemExit)
-      end
-    end
-
-    context 'with report_coverage = false' do
-      before do
-        configuration.report_coverage = false
-      end
-
-      it 'does not report coverage' do
-        expect(OpenapiFirst::Test).not_to receive(:report_coverage)
-
-        configuration.handle_exit
-      end
-    end
-
-    context 'with report_coverage = :warn' do
-      before do
-        configuration.report_coverage = :warn
-      end
-
-      it 'reports coverage, but does not fail' do
-        expect(OpenapiFirst::Test).to receive(:report_coverage)
-
-        configuration.handle_exit
-      end
-    end
+  it 'raises an error with invalid option value' do
+    expect do
+      configuration.report_coverage = :fatal
+    end.to raise_error(ArgumentError)
   end
 end

--- a/spec/test/coverage_spec.rb
+++ b/spec/test/coverage_spec.rb
@@ -21,8 +21,11 @@ RSpec.describe OpenapiFirst::Test::Coverage do
     )))
   end
 
-  before(:each) do
-    OpenapiFirst::Test.setup { |test| test.register(definition) }
+  before do
+    OpenapiFirst::Test.setup do |test|
+      test.register(definition)
+      test.report_coverage = false
+    end
   end
 
   let(:valid_request) { Rack::Request.new(Rack::MockRequest.env_for('/roll', method: 'POST')) }

--- a/spec/test/methods_spec.rb
+++ b/spec/test/methods_spec.rb
@@ -25,14 +25,6 @@ RSpec.describe OpenapiFirst::Test::Methods do
   end
 
   context 'with RSpec' do
-    let(:app) do
-      lambda do |_|
-        res = Rack::Response.new(JSON.generate(hello: 'there'))
-        res.content_type = 'application/json'
-        res.finish
-      end
-    end
-
     context 'with metadata', api: :v1 do
       include OpenapiFirst::Test::Methods
       include Rack::Test::Methods

--- a/spec/test/observe_spec.rb
+++ b/spec/test/observe_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::Test::Observe do
+  RSpec.shared_examples 'an observed app' do
+    it 'injects request/response validation' do
+      described_class.observe(app)
+
+      expect(definition).to receive(:validate_request)
+      expect(definition).to receive(:validate_response)
+
+      callable.call(Rack::MockRequest.env_for('/'))
+    end
+  end
+
+  let(:definition) { OpenapiFirst.load('./examples/openapi.yaml') }
+  let(:callable) { app }
+
+  before do
+    OpenapiFirst::Test.register(definition)
+  end
+
+  context 'with a simple class' do
+    let(:app) do
+      Class.new do
+        def call(_env)
+          Rack::Response.new.finish
+        end
+      end
+    end
+
+    let(:callable) { app.new }
+
+    it_behaves_like 'an observed app'
+
+    it 'injects request/response validation only once' do
+      2.times { described_class.observe(app) }
+
+      expect(definition).to receive(:validate_request).once
+      expect(definition).to receive(:validate_response).once
+
+      callable.call({})
+    end
+  end
+
+  context 'with a class that has no call method' do
+    let(:app) do
+      Class.new
+    end
+
+    it 'raises an error when trying to observe' do
+      expect do
+        described_class.observe(app)
+      end.to raise_error OpenapiFirst::Test::ObserveError
+
+      app.instance_methods.include?(:call)
+    end
+  end
+
+  context 'with a Sinatra app' do
+    require 'sinatra/base'
+
+    let(:app) do
+      Class.new(Sinatra::Base)
+    end
+    it_behaves_like 'an observed app'
+
+    context 'when using the class method' do
+      let(:callable) { app }
+
+      it_behaves_like 'an observed app'
+    end
+  end
+
+  context 'with a Rails app' do
+    require 'rails'
+    require 'action_controller/railtie'
+
+    before do
+      Rails.logger = Logger.new(StringIO.new)
+    end
+
+    let(:app) do
+      Class.new(Rails::Application)
+    end
+
+    it_behaves_like 'an observed app'
+  end
+end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -95,10 +95,18 @@ RSpec.describe OpenapiFirst::Test do
       expect(described_class.definitions[:default].filepath).to eq(OpenapiFirst.load('./examples/openapi.yaml').filepath)
     end
 
-    it 'can skip responses for coverage' do
+    it 'can skip_response_coverage' do
       described_class.setup do |test|
         test.register('./examples/openapi.yaml')
         test.skip_response_coverage { |res| res.status == '401' }
+      end
+      expect(described_class::Coverage.plans.first.tasks.count).to eq(2)
+    end
+
+    it 'can skip_response_coverage_if' do
+      described_class.setup do |test|
+        test.register('./examples/openapi.yaml')
+        test.skip_response_coverage_if { |res| res.status == '401' }
       end
       expect(described_class::Coverage.plans.first.tasks.count).to eq(2)
     end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -3,6 +3,10 @@
 require 'minitest'
 
 RSpec.describe OpenapiFirst::Test do
+  before do
+    described_class.configuration.report_coverage = false
+  end
+
   describe '.minitest?' do
     it 'detects minitest' do
       test_case = Class.new(Minitest::Test)
@@ -177,11 +181,11 @@ RSpec.describe OpenapiFirst::Test do
         described_class.definitions.clear
       end
 
-      it 'reports 0% by default' do
+      it 'reports no detected requests by default' do
         output = StringIO.new
         allow($stdout).to receive(:puts).and_invoke(output.method(:puts))
         described_class.report_coverage
-        expect(output.string).to include('0%')
+        expect(output.string).to include('Coverage did not detect any API requests')
       end
     end
   end
@@ -325,6 +329,7 @@ RSpec.describe OpenapiFirst::Test do
         described_class.setup do |test|
           test.register(definition)
           test.response_raise_error = false
+          test.report_coverage = false
         end
       end
 

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe OpenapiFirst::Test do
       expect(OpenapiFirst::Test).to receive(:report_coverage)
       expect do
         described_class.handle_exit
-      end.to raise_error(OpenapiFirst::Test::CoverageError)
+      end.to raise_error(SystemExit)
     end
 
     context 'with full coverage' do
@@ -177,7 +177,7 @@ RSpec.describe OpenapiFirst::Test do
         expect(OpenapiFirst::Test).to receive(:report_coverage)
         expect do
           described_class.handle_exit
-        end.to raise_error(OpenapiFirst::Test::CoverageError)
+        end.to raise_error(SystemExit)
       end
     end
 

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -97,10 +97,10 @@ RSpec.describe OpenapiFirst::Test do
       expect(described_class::Coverage.plans.first.tasks.count).to eq(2)
     end
 
-    it 'can skip_response_coverage_if' do
+    it 'can skip_response_coverage' do
       described_class.setup do |test|
         test.register('./examples/openapi.yaml')
-        test.skip_response_coverage_if { |res| res.status == '401' }
+        test.skip_response_coverage { |res| res.status == '401' }
       end
       expect(described_class::Coverage.plans.first.tasks.count).to eq(2)
     end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe OpenapiFirst::Test do
 
   describe 'Callable[]' do
     it 'returns a Module that can call the api' do
-      described_class.register(definition, as: :some)
-      mod = described_class::Callable[api: :some]
+      mod = described_class::Callable[definition]
       app.prepend(mod)
 
       expect(definition).to receive(:validate_request)
@@ -33,16 +32,6 @@ RSpec.describe OpenapiFirst::Test do
 
       expect(definition).to receive(:validate_request)
       expect(definition).to receive(:validate_response)
-
-      app.new.call({})
-    end
-
-    it 'injects request/response validation just once' do
-      described_class.register(definition, as: :some)
-      2.times { described_class.observe(app, api: :some) }
-
-      expect(definition).to receive(:validate_request).once
-      expect(definition).to receive(:validate_response).once
 
       app.new.call({})
     end


### PR DESCRIPTION
OpenapiFirst::Test is now stricter and more configurable

Changes:
- Changed OpenapiFirst::Test to raises an "invalid response" error if it sees an invalid response (https://github.com/ahx/openapi_first/issues/366).
  You can change this back to the old behavior by setting `OpenapiFirst::Test::Configuration#response_raise_error = false` (but you shouldn't).
- Added `Test.setup { it.observe(MyApp) }`, `Test.observe(App, api: :my_api)` and internal `Test::Callable[]` to inject request/response validation in rack app as an alternative to overwrite the `app` method in a test
- Added `Test::Configuration#ignored_unknown_status` to configure response status(es) that do not have to be descriped in the API description. 404 statuses are ignored by default.
- Changed `OpenapiFirst::Test` to make tests fail if API description is not covered by tests. You can adapt this behavior via `OpenapiFirst::Test.setup` / `skip_response_coverage` or deactivate coverage with `OpenapiFirst::Test::Configuration#report_coverage = false` or `report_coverage = :warn`

Solves https://github.com/ahx/openapi_first/issues/366