### PR TITLE
Return 400 if Rack cannot parse query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Return 400 if Rack cannot parse query string instead of raising an exception. Fixes https://github.com/ahx/openapi_first/issues/372
+
 ## 2.7.3
 
 - Accept loading OAD documents with numeric status codes. Fixes "Unknown reference" error. https://github.com/ahx/openapi_first/issues/367

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     openapi_first (2.7.3)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
-      openapi_parameters (>= 0.3.3, < 2.0)
+      openapi_parameters (>= 0.5.1, < 2.0)
       rack (>= 2.2, < 4.0)
 
 GEM
@@ -71,7 +71,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
-    openapi_parameters (0.5.0)
+    openapi_parameters (0.5.1)
       rack (>= 2.2)
     parallel (1.27.0)
     parser (3.3.8.0)

--- a/lib/openapi_first/request_parser.rb
+++ b/lib/openapi_first/request_parser.rb
@@ -27,11 +27,19 @@ module OpenapiFirst
     def parse(request, route_params:)
       ParsedRequest.new(
         path: @path_parser&.unpack(route_params),
-        query: @query_parser&.unpack(request.env[Rack::QUERY_STRING]),
+        query: parse_query(request.env[Rack::QUERY_STRING]),
         headers: @headers_parser&.unpack_env(request.env),
         cookies: @cookies_parser&.unpack(request.env[Rack::HTTP_COOKIE]),
         body: @body_parsers&.call(request)
       )
+    end
+
+    private
+
+    def parse_query(query_string)
+      @query_parser&.unpack(query_string)
+    rescue OpenapiParameters::InvalidParameterError
+      Failure.fail!(:invalid_query, message: 'Invalid query parameter.')
     end
   end
 end

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'hana', '~> 1.3'
   spec.add_dependency 'json_schemer', '>= 2.1', '< 3.0'
-  spec.add_dependency 'openapi_parameters', '>= 0.3.3', '< 2.0'
+  spec.add_dependency 'openapi_parameters', '>= 0.5.1', '< 2.0'
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
 end

--- a/spec/middlewares/request_validation/query_parameter_validation_spec.rb
+++ b/spec/middlewares/request_validation/query_parameter_validation_spec.rb
@@ -52,7 +52,20 @@ RSpec.describe 'Query Parameter validation' do
       get '/search', params
 
       expect(last_response.status).to be 400
-      response_body[:errors][0]
+    end
+
+    it 'returns 400 if query parameter has invalid encoding' do
+      get '/search?birthdate=%E0%A4%A'
+
+      expect(last_response.status).to be 400
+      expect(response_body[:title]).to eq 'Bad Query Parameter'
+    end
+
+    it 'returns 400 if nested[parameter] has invalid encoding' do
+      get '/search?filter=%E0%A4%A'
+
+      expect(last_response.status).to eq 400
+      expect(response_body[:title]).to eq 'Bad Query Parameter'
     end
 
     it 'returns 400 if query parameter has not valid date-time format' do


### PR DESCRIPTION
Return 400 if Rack cannot parse query string instead of raising an exception. 

Fixes https://github.com/ahx/openapi_first/issues/372