### PR TITLE
Fix test no raise invalid request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.9.1
+
 - Fix OpenapiFirst::Test's request validation to not always raise an error, but only for unknown requests
 
 ## 2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix OpenapiFirst::Test's request validation to not always raise an error, but only for unknown requests
+
 ## 2.9.0
 
 - OpenapiFirst::Test now raises an error for unknown requests. You can deactivate with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (2.9.0)
+    openapi_first (2.9.1)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.5.1, < 2.0)

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    openapi_first (2.9.0)
+    openapi_first (2.9.1)
       hana (~> 1.3)
       json_schemer (>= 2.1, < 3.0)
       openapi_parameters (>= 0.5.1, < 2.0)

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -118,7 +118,7 @@ module OpenapiFirst
 
     def self.raise_request_error?(validated_request)
       return false if validated_request.valid?
-      return true if validated_request.known?
+      return false if validated_request.known?
 
       !configuration.ignore_unknown_requests
     end

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '2.9.0'
+  VERSION = '2.9.1'
 end


### PR DESCRIPTION
Fix OpenapiFirst::Test's request validation to not always raise an error, but only for unknown requests