### PR TITLE
Path matching based on regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Here is how to set it up:
     end
     ```
 2. Observe your application. You can do this in multiple ways:
-    - Add an `app` method to your tests, which wraps your application with silent request / response validation. (✷1)
+    - Add an `app` method to your tests (which is called by rack-test) that wraps your application with silent request / response validation.
       ```ruby
       module RequestSpecHelpers
         def app
@@ -188,21 +188,26 @@ Here is how to set it up:
         config.include OpenapiFirst::Test::Methods[MyApp], type: :request
       end
       ```
-4. Run your tests. The Coverage feature will tell you about missing or invalid requests/responses.
+4. Run your tests. The Coverage feature will tell you about missing or invalid requests/responses:
+      ```
+      ✓ GET /stations
+        ✓ 200(application/json)
+        ❌ 200(application/xml) – No responses tracked!
+        ❌ 400(application/problem+json) – No responses tracked!
+      ```
 
-(✷1): It does not matter what method of openapi_first you use to validate requests/responses. Instead of using `OpenapiFirstTest.app` to wrap your application, you could also use the [middlewares](#rack-middlewares) or [test assertion method](#test-assertions), but you would have to do that for all requests/responses defined in your API description to make coverage work.
+      Now add tests for all those "❌" to make them "✓" and you're green!
 
 > [!NOTE]
 > Check out [faraday-openapi](https://codeberg.org/ahx/faraday-openapi) to have your API _client_ validate request/responses against an OAD, which is useful to validate HTTP mocks during testing.
 
 ### Configure test coverage
 
-OpenapiFirst::Test raises an error when a request is not defined. You can deactivate this with:
+OpenapiFirst::Test raises an error when a response status is not defined. You can deactivate this with:
 
 ```ruby
 OpenapiFirst::Test.setup do |test|
-  # …
-  test.ignore_unknown_requests = true
+  [403, 401].each { test.ignored_unknown_status << it }
 end
 ```
 
@@ -225,6 +230,15 @@ OpenapiFirst::Test.setup do |test|
   test.skip_coverage do |path, request_method|
     path == '/bookings/{bookingId}' && requests_method == 'DELETE'
   end
+end
+```
+
+OpenapiFirst::Test raises an error when a request is not defined. You can deactivate this with:
+
+```ruby
+OpenapiFirst::Test.setup do |test|
+  # …
+  test.ignore_unknown_requests = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ Here is how to set it up:
 
 (✷1): It does not matter what method of openapi_first you use to validate requests/responses. Instead of using `OpenapiFirstTest.app` to wrap your application, you could also use the [middlewares](#rack-middlewares) or [test assertion method](#test-assertions), but you would have to do that for all requests/responses defined in your API description to make coverage work.
 
+> [!NOTE]
+> Check out [faraday-openapi](https://codeberg.org/ahx/faraday-openapi) to have your API _client_ validate request/responses against an OAD, which is useful to validate HTTP mocks during testing.
+
 ### Configure test coverage
 
 OpenapiFirst::Test raises an error when a request is not defined. You can deactivate this with:

--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -73,6 +73,8 @@ module OpenapiFirst
               request,
               request_method:,
               path:,
+              path_parameters: parameters.path,
+              use_patterns_for_path_matching: config.use_patterns_for_path_matching,
               content_type: request.content_type,
               allow_empty_content: request.allow_empty_content?
             )
@@ -81,6 +83,8 @@ module OpenapiFirst
                 response,
                 request_method:,
                 path:,
+                path_parameters: parameters.path,
+                use_patterns_for_path_matching: config.use_patterns_for_path_matching,
                 status: response.status,
                 response_content_type: response.content_type
               )

--- a/lib/openapi_first/configuration.rb
+++ b/lib/openapi_first/configuration.rb
@@ -14,12 +14,14 @@ module OpenapiFirst
       @request_validation_error_response = OpenapiFirst.find_error_response(:default)
       @request_validation_raise_error = false
       @response_validation_raise_error = true
+      @use_patterns_for_path_matching = false
       @hooks = (HOOKS.map { [_1, Set.new] }).to_h
       @path = nil
     end
 
     attr_reader :request_validation_error_response, :hooks
-    attr_accessor :request_validation_raise_error, :response_validation_raise_error, :path
+    attr_accessor :request_validation_raise_error, :response_validation_raise_error, :path,
+                  :use_patterns_for_path_matching
 
     def clone
       copy = super

--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -39,16 +39,16 @@ module OpenapiFirst
     end
 
     # Add a request definition
-    def add_request(request, request_method:, path:, content_type: nil, allow_empty_content: false)
-      route = route_at(path, request_method)
+    def add_request(request, request_method:, path:, path_parameters: [], use_patterns_for_path_matching: false, content_type: nil, allow_empty_content: false)
+      route = route_at(path, request_method, path_parameters, use_patterns_for_path_matching)
       requests = route[:requests]
       requests[content_type] = request
       requests[nil] = request if allow_empty_content
     end
 
     # Add a response definition
-    def add_response(response, request_method:, path:, status:, response_content_type: nil)
-      (route_at(path, request_method)[:responses][status] ||= {})[response_content_type] = response
+    def add_response(response, request_method:, path:, path_parameters: [], use_patterns_for_path_matching: false, status:, response_content_type: nil)
+      (route_at(path, request_method, path_parameters, use_patterns_for_path_matching)[:responses][status] ||= {})[response_content_type] = response
     end
 
     # Return all request objects that match the given path and request method
@@ -74,10 +74,12 @@ module OpenapiFirst
 
     private
 
-    def route_at(path, request_method)
+    def route_at(path, request_method, path_parameters, use_patterns_for_path_matching)
       request_method = request_method.upcase
       path_item = if PathTemplate.template?(path)
-                    @dynamic[path] ||= { template: PathTemplate.new(path) }
+                    @dynamic[path] ||= {
+                      template: PathTemplate.new(path, path_parameters, use_patterns_for_path_matching)
+                    }
                   else
                     @static[path] ||= {}
                   end

--- a/lib/openapi_first/router/path_template.rb
+++ b/lib/openapi_first/router/path_template.rb
@@ -72,7 +72,7 @@ module OpenapiFirst
       def pattern_with_correct_end(pattern)
         return pattern[..-2] if pattern.end_with?('$')
         return pattern[..-3] if pattern.end_with?('\Z')
-        return pattern[..-4] if pattern.end_with?('\z')
+        return pattern[..-3] if pattern.end_with?('\z')
 
         "#{pattern}[^/?#]*$"
       end

--- a/spec/router/path_template_spec.rb
+++ b/spec/router/path_template_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe OpenapiFirst::Router::PathTemplate do
+  let(:path_parameters) { [] }
+  let(:use_patterns_for_path_matching) { false }
+
   describe '.template?' do
     specify do
       expect(described_class.template?('/totally/static')).to be(false)
@@ -10,52 +13,144 @@ RSpec.describe OpenapiFirst::Router::PathTemplate do
 
   describe '#to_s' do
     specify do
-      expect(described_class.new('/stations/{id}').to_s).to eq('/stations/{id}')
+      expect(
+        described_class.new('/stations/{id}', path_parameters, use_patterns_for_path_matching).to_s
+      ).to eq('/stations/{id}')
     end
   end
 
   describe '#match' do
     it 'returns empty params with exact string match' do
-      expect(described_class.new('/a/b').match('/a/b')).to eq({})
+      expect(
+        described_class.new('/a/b', path_parameters, use_patterns_for_path_matching)
+          .match('/a/b')
+      ).to eq({})
     end
 
     it 'returns params with multiple matches' do
-      expect(described_class.new('/{a}/{b}').match('/1/2')).to eq({ 'a' => '1', 'b' => '2' })
+      expect(
+        described_class.new('/{a}/{b}', path_parameters, use_patterns_for_path_matching )
+          .match('/1/2')
+      ).to eq({ 'a' => '1', 'b' => '2' })
     end
 
     it 'ignores trailing slashes in paths' do
-      expect(described_class.new('/{a}/{b}').match('/1/2/')).to eq({ 'a' => '1', 'b' => '2' })
+      expect(
+        described_class.new('/{a}/{b}', path_parameters, use_patterns_for_path_matching)
+          .match('/1/2/')
+      ).to eq({ 'a' => '1', 'b' => '2' })
     end
 
     it 'returns params with kebab-case names' do
-      expect(described_class.new('/kebab-path/{ke-bab}/{under_score}').match('/kebab-path/1/2'))
-        .to eq({ 'ke-bab' => '1', 'under_score' => '2' })
+      expect(
+        described_class.new('/kebab-path/{ke-bab}/{under_score}', path_parameters, use_patterns_for_path_matching)
+          .match('/kebab-path/1/2')
+      ).to eq({ 'ke-bab' => '1', 'under_score' => '2' })
     end
 
     it 'returns params where variable is in the middle' do
-      expect(described_class.new('/stuff/{id}/things').match('/stuff/42/things')).to eq({ 'id' => '42' })
+      expect(
+        described_class.new('/stuff/{id}/things', path_parameters, use_patterns_for_path_matching)
+          .match('/stuff/42/things')
+      ).to eq({ 'id' => '42' })
     end
 
     it 'works with /stuff/{a}..{b}' do
-      expect(described_class.new('/stuff/{a}..{b}').match('/stuff/some..other')).to eq({ 'a' => 'some',
-                                                                                         'b' => 'other' })
+      expect(
+        described_class.new('/stuff/{a}..{b}', path_parameters, use_patterns_for_path_matching)
+          .match('/stuff/some..other')
+      ).to eq({ 'a' => 'some', 'b' => 'other' })
     end
 
     it 'works with special characters in path' do
-      expect(described_class.new('/stuff/{range}').match('/stuff/some..other')).to eq({ 'range' => 'some..other' })
-      expect(described_class.new('/stuff/{bang}').match('/stuff/bang!boom!')).to eq({ 'bang' => 'bang!boom!' })
+      expect(
+        described_class.new('/stuff/{range}', path_parameters, use_patterns_for_path_matching)
+          .match('/stuff/some..other')
+      ).to eq({ 'range' => 'some..other' })
+      expect(
+        described_class.new('/stuff/{bang}', path_parameters, use_patterns_for_path_matching)
+          .match('/stuff/bang!boom!')
+      ).to eq({ 'bang' => 'bang!boom!' })
     end
 
     it 'returns nil without match' do
-      expect(described_class.new('/{a}/middle/{b}').match('/1/2/3')).to be_nil
+      expect(
+        described_class.new('/{a}/middle/{b}', path_parameters, use_patterns_for_path_matching)
+          .match('/1/2/3')
+      ).to be_nil
     end
 
     it 'returns nil when path has more parts' do
-      expect(described_class.new('/foo/{id}').match('/foo/middle/bar')).to be_nil
+      expect(
+        described_class.new('/foo/{id}', path_parameters, use_patterns_for_path_matching)
+          .match('/foo/middle/bar')
+      ).to be_nil
     end
 
     it 'returns nil when path without variables does not match' do
-      expect(described_class.new('/a/b').match('/1/2')).to be_nil
+      expect(
+        described_class.new('/a/b', path_parameters, use_patterns_for_path_matching)
+          .match('/1/2')
+      ).to be_nil
+    end
+
+    context 'when using path parameters with patterns' do
+      let(:path_parameters) do
+        [
+          { 'name' => 'foo', 'schema' => { 'pattern' => '^foo$' } },
+          { 'name' => 'bar', 'schema' => { 'pattern' => 'bar' } }
+        ]
+      end
+
+      context 'when use_patterns_for_path_matching is false' do
+        let(:use_patterns_for_path_matching) { false }
+
+        it 'matches when the pattern matches' do
+          expect(
+            described_class.new('/{foo}', path_parameters, use_patterns_for_path_matching)
+              .match('/foo')
+          ).to eq({ 'foo' => 'foo' })
+        end
+
+        it 'matches even though the pattern does not match' do
+          expect(
+            described_class.new('/{foo}', path_parameters, use_patterns_for_path_matching)
+              .match('/bar')
+          ).to eq({ 'foo' => 'bar' })
+        end
+      end
+
+      context 'when use_patterns_for_path_matching is true' do
+        let(:use_patterns_for_path_matching) { true }
+
+        it 'matches when the pattern matches' do
+          expect(
+            described_class.new('/{foo}', path_parameters, use_patterns_for_path_matching)
+              .match('/foo')
+          ).to eq({ 'foo' => 'foo' })
+        end
+
+        it 'does not match when the pattern does not match' do
+          expect(
+            described_class.new('/{foo}', path_parameters, use_patterns_for_path_matching)
+              .match('/bar')
+          ).to be_nil
+        end
+
+        it 'uses start and end anchors correctly' do
+          expect(
+            described_class.new('/{foo}', path_parameters, use_patterns_for_path_matching)
+              .match('/123foo456')
+          ).to be_nil
+        end
+
+        it 'uses the lack of start and end anchors correctly' do
+          expect(
+            described_class.new('/{bar}', path_parameters, use_patterns_for_path_matching)
+              .match('/123bar456')
+          ).to eq({ 'bar' => '123bar456' })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This makes it possible to match paths based on the regex provided in the `pattern` of a path parameter.

As described in #386 this might be needed in some weird APIs