### PR TITLE
Filter on parameter lenght if multiple endpoints match a request

### DIFF
--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -97,10 +97,15 @@ module OpenapiFirst
       found = @static[request_path]
       return [found, {}] if found
 
-      @dynamic.find do |_path, path_item|
+      matches = @dynamic.filter_map do |_path, path_item|
         params = path_item[:template].match(request_path)
-        return [path_item, params] if params
+        next unless params
+
+        [path_item, params, params.values.sum(&:length)]
       end
+
+      matches&.min_by { |_path_item, _params, length| length }
+             &.then { |path_item, params, _length| [path_item, params] }
     end
   end
 end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe OpenapiFirst::Router do
       [
         double(path: '/{id}', request_method: 'get'),
         double(path: '/{id}', request_method: 'patch'),
-        double(path: '/a', request_method: 'get')
+        double(path: '/a', request_method: 'get'),
+        double(path: '/a.{format}', request_method: 'get')
       ]
     end
 
@@ -28,6 +29,12 @@ RSpec.describe OpenapiFirst::Router do
 
     it 'returns an incomplete match for unknown path' do
       expect(router.match('GET', '/c/d').error).to have_attributes(type: :not_found)
+    end
+
+    it 'returns a match with only a request method' do
+      match = router.match('GET', '/a.json')
+      expect(match.request_definition.path).to eq('/a.{format}')
+      expect(match.request_definition).to be(requests[3])
     end
 
     it 'returns an incomplete match for unknown request method' do

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OpenapiFirst::Router do
         double(path: '/{id}', request_method: 'get'),
         double(path: '/{id}', request_method: 'patch'),
         double(path: '/a', request_method: 'get'),
-        double(path: '/a.{format}', request_method: 'get')
+        double(path: '/a{format}', request_method: 'get')
       ]
     end
 


### PR DESCRIPTION
Like the title says, this PR selects all the endpoints that match a request and returns the one that has has the minimum amount of characters allocated to the parameters.

Example:
if you have these endpoints
```
/foo{format}
/foobar{format}
```
then `/foobar.json` will match the second endpoint with `.json` as `format`
instead of matchin the first and having `bar.json` as `format`

discussed in https://github.com/ahx/openapi_first/issues/386#issuecomment-3195564352
related to #388