### PR TITLE
Add `Test::Configuration#ignore_all_unknown_status = true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Add `OpenapiFirst::Test::Configuration#ignore_unknown_responses=` (use only temporarily when working with an unmaintained OAD)
+- Add `OpenapiFirst::Test::Configuration#ignore_all_unknown_status=`. When this is set to true, it won't complain about undefined response statuses it sees during a test run. Use with caution.
+- Failure type `:response_not_found` was split into two more specific types `:response_content_type_not_found` and `:response_status_not_found`. This should be mostly internal stuff.
 
 ## 2.11.1
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,15 @@ OpenapiFirst::Test.setup do |test|
 end
 ```
 
+Or you can ignore all unknown response status:
+
+```ruby
+OpenapiFirst::Test.setup do |test|
+  # …
+  test.ignore_all_unknown_status = true
+end
+```
+
 Exclude certain _responses_ from coverage with `skip_coverage`:
 
 ```ruby

--- a/lib/openapi_first/failure.rb
+++ b/lib/openapi_first/failure.rb
@@ -13,7 +13,8 @@ module OpenapiFirst
       invalid_header: [RequestInvalidError, 'Request header is invalid:'],
       invalid_path: [RequestInvalidError, 'Path segment is invalid:'],
       invalid_cookie: [RequestInvalidError, 'Cookie value is invalid:'],
-      response_not_found: [ResponseNotFoundError],
+      response_content_type_not_found: [ResponseNotFoundError],
+      response_status_not_found: [ResponseNotFoundError],
       invalid_response_body: [ResponseInvalidError, 'Response body is invalid:'],
       invalid_response_header: [ResponseInvalidError, 'Response header is invalid:']
     }.freeze

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -123,8 +123,8 @@ module OpenapiFirst
       !configuration.ignore_unknown_requests
     end
 
-    def self.raise_response_error?(validated_response)
-      configuration.response_raise_error && !configuration.ignore_response?(validated_response)
+    def self.raise_response_error?(invalid_response)
+      configuration.response_raise_error && !configuration.ignore_response?(invalid_response)
     end
 
     def self.uninstall

--- a/lib/openapi_first/test/configuration.rb
+++ b/lib/openapi_first/test/configuration.rb
@@ -12,7 +12,7 @@ module OpenapiFirst
         @skip_coverage = nil
         @response_raise_error = true
         @ignored_unknown_status = [404]
-        @ignore_unknown_responses = false
+        @ignore_all_unknown_response_status = false
         @report_coverage = true
         @ignore_unknown_requests = false
         @registry = {}
@@ -32,7 +32,7 @@ module OpenapiFirst
       end
 
       attr_accessor :coverage_formatter_options, :coverage_formatter, :response_raise_error,
-                    :ignore_unknown_requests, :ignore_unknown_responses
+                    :ignore_unknown_requests, :ignore_all_unknown_response_status
       attr_reader :registry, :apps, :report_coverage, :ignored_unknown_status, :minimum_coverage
 
       # Configure report coverage
@@ -65,10 +65,14 @@ module OpenapiFirst
         @skip_coverage = block
       end
 
-      def ignore_response?(validated_response)
-        return true if @ignore_unknown_responses
+      alias ignore_all_unknown_response_status? ignore_all_unknown_response_status
 
-        ignored_unknown_status.include?(validated_response.status)
+      def ignore_response?(validated_response)
+        return false if validated_response.known?
+
+        return true if ignored_unknown_status.include?(validated_response.status)
+
+        ignore_all_unknown_response_status? && validated_response.error.type == :response_status_not_found
       end
     end
   end

--- a/spec/router/find_response_spec.rb
+++ b/spec/router/find_response_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe OpenapiFirst::Router::FindResponse do
         ]
         expect(find(responses, 409, 'application/json')).to have_attributes(
           response: nil, error: have_attributes(
-            type: :response_not_found,
+            type: :response_status_not_found,
             message: 'Status 409 is not defined for GET /stations. Defined statuses are: 200, 201.'
           )
         )
@@ -85,7 +85,7 @@ RSpec.describe OpenapiFirst::Router::FindResponse do
         message = 'Content-Type should be application/text or application/xml, but was application/json for GET /stations'
         expect(find(responses, 200, 'application/json')).to have_attributes(
           response: nil,
-          error: have_attributes(type: :response_not_found, message:)
+          error: have_attributes(type: :response_content_type_not_found, message:)
         )
       end
     end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -606,10 +606,20 @@ RSpec.describe OpenapiFirst::Test do
       end
     end
 
-    it 'raises an error' do
-      expect do
-        app.call(Rack::MockRequest.env_for('/roll', method: 'POST'))
-      end.to raise_error(OpenapiFirst::ResponseNotFoundError)
+    context 'when response status is unknown' do
+      it 'raises an error' do
+        expect do
+          app.call(Rack::MockRequest.env_for('/roll', method: 'POST'))
+        end.to raise_error(OpenapiFirst::ResponseNotFoundError)
+      end
+    end
+
+    context 'when response content-type is unknown' do
+      it 'raises an error' do
+        expect do
+          app.call(Rack::MockRequest.env_for('/roll', method: 'POST'))
+        end.to raise_error(OpenapiFirst::ResponseNotFoundError)
+      end
     end
 
     context 'with ignored_unknown_status' do
@@ -624,9 +634,9 @@ RSpec.describe OpenapiFirst::Test do
       end
     end
 
-    context 'with ignore_unknown_responses = true' do
+    context 'with ignore_all_unknown_response_status = true' do
       before(:each) do
-        described_class.configuration.ignore_unknown_responses = true
+        described_class.configuration.ignore_all_unknown_response_status = true
       end
 
       it 'does not raise an error' do


### PR DESCRIPTION
When this is set to true, it won't complain about undefined response statuses it sees during a test run.