### PR TITLE
Ignore trailing slashes when routing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Breaking: Trailing slashes are no longer ignored in dynamic paths. See [#403](https://github.com/ahx/openapi_first/issues/403).
 - Remove superflous `Test::Coverage.current_run, .plans, .install, .uninstall`
 - Update dependency `openapi_paramters` to >= 0.7.0, because that version fixes unpacking exploded deepObject paramters
 - Add `OpenapiFirst::Test::Configuration#ignore_unknown_response_status=`. When this is set to true, it won't complain about undefined response statuses it sees during a test run. Use with caution.

--- a/lib/openapi_first/router/path_template.rb
+++ b/lib/openapi_first/router/path_template.rb
@@ -41,7 +41,7 @@ module OpenapiFirst
           part.start_with?('{') ? ALLOWED_PARAMETER_CHARACTERS : Regexp.escape(part)
         end
 
-        %r{^#{parts.join}/?$}
+        /^#{parts.join}$/
       end
     end
   end

--- a/spec/router/path_template_spec.rb
+++ b/spec/router/path_template_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe OpenapiFirst::Router::PathTemplate do
       expect(described_class.new('/{a}/{b}').match('/1/2')).to eq({ 'a' => '1', 'b' => '2' })
     end
 
-    it 'ignores trailing slashes in paths' do
-      expect(described_class.new('/{a}/{b}').match('/1/2/')).to eq({ 'a' => '1', 'b' => '2' })
+    it 'respect trailing slashes in paths' do
+      expect(described_class.new('/{a}/{b}').match('/1/2/')).to be_nil
     end
 
     it 'returns params with kebab-case names' do


### PR DESCRIPTION
Related to https://github.com/ahx/openapi_first/issues/403