### PR TITLE
Introduce ChildConfiguration to point to global configuration

### DIFF
--- a/lib/openapi_first.rb
+++ b/lib/openapi_first.rb
@@ -5,6 +5,7 @@ require_relative 'openapi_first/file_loader'
 require_relative 'openapi_first/errors'
 require_relative 'openapi_first/registry'
 require_relative 'openapi_first/configuration'
+require_relative 'openapi_first/child_configuration'
 require_relative 'openapi_first/definition'
 require_relative 'openapi_first/version'
 require_relative 'openapi_first/middlewares/response_validation'
@@ -29,7 +30,8 @@ module OpenapiFirst
   # @return [Configuration]
   # @yield [Configuration]
   def self.configure
-    yield configuration
+    @configuration = Configuration.new
+    yield @configuration if block_given?
   end
 
   ERROR_RESPONSES = {} # rubocop:disable Style/MutableConstant

--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -125,7 +125,7 @@ module OpenapiFirst
       end
 
       Schema::Hash.new(schemas, required:, configuration: schemer_configuration,
-                                after_property_validation: config.hooks[:after_request_parameter_property_validation])
+                                after_property_validation: config.after_request_parameter_property_validation)
     end
 
     def build_requests(path:, request_method:, operation_object:, parameters:)
@@ -139,7 +139,7 @@ module OpenapiFirst
       content_objects.map do |content_type, content_object|
         content_schema = content_object['schema'].schema(
           configuration: schemer_configuration,
-          after_property_validation: config.hooks[:after_request_body_property_validation]
+          after_property_validation: config.after_request_body_property_validation
         )
         Request.new(path:, request_method:, parameters:,
                     operation_object: operation_object.resolved,

--- a/lib/openapi_first/child_configuration.rb
+++ b/lib/openapi_first/child_configuration.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  # A subclass to configuration that points to its parent
+  class ChildConfiguration < Configuration
+    def initialize(parent:)
+      super()
+      @parent = parent
+      @request_validation_error_response = parent.request_validation_error_response
+      @request_validation_raise_error = parent.request_validation_raise_error
+      @response_validation_raise_error = parent.response_validation_raise_error
+      @path = parent.path
+    end
+
+    private attr_reader :parent
+
+    HOOKS.each do |hook|
+      define_method(hook) do |&block|
+        return hooks[hook].chain(parent.hooks[hook]) if block.nil?
+
+        hooks[hook] << block
+        block
+      end
+    end
+  end
+end

--- a/lib/openapi_first/configuration.rb
+++ b/lib/openapi_first/configuration.rb
@@ -25,14 +25,14 @@ module OpenapiFirst
     attr_reader :request_validation_error_response, :hooks
     attr_accessor :request_validation_raise_error, :response_validation_raise_error, :path
 
-    def clone
-      copy = super
-      copy.instance_variable_set(:@hooks, @hooks&.transform_values(&:clone))
-      copy
+    def child
+      ChildConfiguration.new(parent: self)
     end
 
     HOOKS.each do |hook|
       define_method(hook) do |&block|
+        return hooks[hook] if block.nil?
+
         hooks[hook] << block
         block
       end

--- a/lib/openapi_first/definition.rb
+++ b/lib/openapi_first/definition.rb
@@ -73,7 +73,7 @@ module OpenapiFirst
       else
         route.request_definition.validate(request, route_params: route.params)
       end.tap do |validated|
-        @config.hooks[:after_request_validation].each { |hook| hook.call(validated, self) }
+        @config.after_request_validation.each { |hook| hook.call(validated, self) }
         raise validated.error.exception(validated) if validated.error && raise_error
       end
     end
@@ -95,7 +95,7 @@ module OpenapiFirst
                   else
                     response_match.response.validate(rack_response)
                   end
-      @config.hooks[:after_response_validation]&.each { |hook| hook.call(validated, rack_request, self) }
+      @config.after_response_validation&.each { |hook| hook.call(validated, rack_request, self) }
       raise validated.error.exception(validated) if raise_error && validated.invalid?
 
       validated

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -130,8 +130,8 @@ module OpenapiFirst
 
     def self.uninstall
       configuration = OpenapiFirst.configuration
-      configuration.hooks[:after_request_validation].delete(@after_request_validation)
-      configuration.hooks[:after_response_validation].delete(@after_response_validation)
+      configuration.after_request_validation.delete(@after_request_validation)
+      configuration.after_response_validation.delete(@after_response_validation)
       definitions.clear
       @configuration = nil
       @installed = nil

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe OpenapiFirst::Configuration do
-  describe '#after' do
+  describe '#after_...' do
     it 'adds a hook' do
       config = OpenapiFirst::Configuration.new
       called = []
@@ -9,7 +9,7 @@ RSpec.describe OpenapiFirst::Configuration do
         called << request
       end
 
-      config.hooks[:after_request_validation].each { |hook| hook.call('request') }
+      config.after_request_validation.each { |hook| hook.call('request') }
       expect(called).to eq(%w[request])
     end
 
@@ -18,7 +18,7 @@ RSpec.describe OpenapiFirst::Configuration do
       config.after_request_validation { _1 }
       config.after_request_validation { _1 }
 
-      expect(config.hooks[:after_request_validation].size).to eq(2)
+      expect(config.after_request_validation.size).to eq(2)
     end
   end
 
@@ -54,22 +54,34 @@ RSpec.describe OpenapiFirst::Configuration do
     end
   end
 
-  describe '#clone' do
+  describe '#child' do
     it 'clones actions' do
       config = OpenapiFirst::Configuration.new
       config.after_request_validation { |request| request }
-      expect(config.hooks[:after_request_validation].size).to eq(1)
-      cloned = config.clone
+      expect(config.after_request_validation.size).to eq(1)
+      cloned = config.child
       cloned.after_request_validation { |request| request }
-      expect(cloned.hooks[:after_request_validation].size).to eq(2)
-      expect(config.hooks[:after_request_validation].size).to eq(1)
+      expect(cloned.after_request_validation.size).to eq(2)
+      expect(config.after_request_validation.size).to eq(1)
     end
 
     it 'clones empty configs' do
       config = OpenapiFirst::Configuration.new
-      expect(config.hooks.values.all?(&:empty?)).to be(true)
-      cloned = config.clone
-      expect(cloned.hooks.values.all?(&:empty?)).to be(true)
+      expect(config.after_request_validation.to_a).to be_empty
+      cloned = config.child
+      expect(cloned.after_request_validation.to_a).to be_empty
+    end
+
+    it 'allows adding hooks to the parent config after cloning' do
+      parent = OpenapiFirst::Configuration.new
+      parent.after_request_validation { |request| request }
+
+      child = parent.child
+
+      expect(child.after_request_validation.size).to eq(1)
+      parent.after_request_validation { |request| request }
+      expect(parent.after_request_validation.size).to eq(2)
+      expect(child.after_request_validation.size).to eq(2)
     end
   end
 end

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Hooks' do
         config.after_request_validation(&myproc)
       end
       definition.validate_request(build_request('/pets?limit=24'))
-      definition.config.hooks[:after_request_validation].delete(myproc)
+      definition.config.after_request_validation.delete(myproc)
       definition.validate_request(build_request('/pets?limit=24'))
 
       expect(called).to eq([['listPets', true]])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
+    OpenapiFirst.configure
     OpenapiFirst::Test.definitions.clear
     OpenapiFirst.definitions.clear
     OpenapiFirst::Test.uninstall

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -379,17 +379,17 @@ RSpec.describe OpenapiFirst::Test do
     it 'installs global hooks' do
       described_class.install
 
-      hooks = OpenapiFirst.configuration.hooks
-      expect(hooks[:after_request_validation]).not_to be_empty
-      expect(hooks[:after_response_validation]).not_to be_empty
+      config = OpenapiFirst.configuration
+      expect(config.after_request_validation).not_to be_empty
+      expect(config.after_response_validation).not_to be_empty
     end
 
     it 'does not install hooks multiple times' do
       2.times { described_class.install }
 
-      hooks = OpenapiFirst.configuration.hooks
-      expect(hooks[:after_request_validation].count).to eq(1)
-      expect(hooks[:after_response_validation].count).to eq(1)
+      config = OpenapiFirst.configuration
+      expect(config.after_request_validation.count).to eq(1)
+      expect(config.after_response_validation.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
This should solve issues where hooks that were added via OpenapiFirst::Test have not been called