### PR TITLE
Add OpenapiFirst::Test::App to wrap a rack app and delegate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Breaking: Trailing slashes are no longer ignored in dynamic paths. See [#403](https://github.com/ahx/openapi_first/issues/403).
   Before this change `GET /things/24/` matched `/things/{id}:`, but it no longer does.
 - Breaking: Failure type `:response_not_found` was split into two more specific types `:response_content_type_not_found` and `:response_status_not_found`. This should be mostly internal stuff. So if your custom error response used `response_not_found`, you will have to adapt.
+- `OpenapiFirst::Test.app` now returns an instance of `OpenapiFirst::Test::App`, instead of `Rack::Builer` and delegates methods other than `#call` to the original app. This wrapper adds validated requests, responses to the rack env at `env[OpenapiFirst::Test::REQUEST]`, `env[OpenapiFirst::Test::RESPONSE]`
 
 ### Added
 - The Coverage feature in `OpenapiFirst::Test` now supports parallel tests via a DRB client/sever. Thanks to Richard! See [#394](https://github.com/ahx/openapi_first/issues/394).

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -9,6 +9,7 @@ module OpenapiFirst
     autoload :Coverage, 'openapi_first/test/coverage'
     autoload :Methods, 'openapi_first/test/methods'
     autoload :Observe, 'openapi_first/test/observe'
+    autoload :App, 'openapi_first/test/app'
     extend Registry
 
     class CoverageError < Error; end
@@ -89,11 +90,8 @@ module OpenapiFirst
     # the middlewares or manual request, response validation.
     def self.app(app, spec: nil, api: :default)
       spec ||= self[api]
-      Rack::Builder.app do
-        use OpenapiFirst::Middlewares::ResponseValidation, spec:, raise_error: false
-        use OpenapiFirst::Middlewares::RequestValidation, spec:, raise_error: false, error_response: false
-        run app
-      end
+
+      App.new(app, api: spec)
     end
 
     def self.install

--- a/lib/openapi_first/test/app.rb
+++ b/lib/openapi_first/test/app.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative 'observe'
+
+module OpenapiFirst
+  module Test
+    REQUEST = 'openapi.test.request'
+    RESPONSE = 'openapi.test.response'
+
+    # A wrapper of the original app
+    # with silent request/response validation to track requests/responses.
+    class App < SimpleDelegator
+      def initialize(app, api:)
+        super(app)
+        @app = app
+        @definition = Test[api]
+      end
+
+      def call(env)
+        request = Rack::Request.new(env)
+        env[Test::REQUEST] = @definition.validate_request(request, raise_error: false)
+        response = @app.call(env)
+        status, headers, body = response
+        env[Test::RESPONSE] =
+          @definition.validate_response(request, Rack::Response[status, headers, body], raise_error: false)
+        response
+      end
+    end
+  end
+end

--- a/spec/test/methods_spec.rb
+++ b/spec/test/methods_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe OpenapiFirst::Test::Methods do
 
         get('/')
 
-        expect(last_request.env[OpenapiFirst::REQUEST].operation_id).to eq('example#root')
+        expect(last_request.env[OpenapiFirst::Test::REQUEST].operation_id).to eq('example#root')
       end
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe OpenapiFirst::Test::Methods do
       test_app = minitest_class.new(1).app
       env = Rack::MockRequest.env_for('/')
       expect(test_app.call(env)).to eq(Rack::Response.new('hello').finish)
-      expect(env[OpenapiFirst::REQUEST]).to be_valid
+      expect(env[OpenapiFirst::Test::REQUEST]).to be_valid
     end
 
     it 'adds an app method that wraps the app for a specific API' do
@@ -115,7 +115,7 @@ RSpec.describe OpenapiFirst::Test::Methods do
       test_app = minitest_class.new(1).app
       env = Rack::MockRequest.env_for('/')
       expect(test_app.call(env)).to eq(Rack::Response.new('hello').finish)
-      expect(env[OpenapiFirst::REQUEST]).to be_valid
+      expect(env[OpenapiFirst::Test::REQUEST]).to be_valid
     end
 
     it 'adds an assert_api_conform method that targets the specified API' do


### PR DESCRIPTION
This changes `OpenapiFirst::Test.app` to return an instance of `OpenapiFirst::Test::App`, instead of `Rack::Builer` that delegates methods other than `#call` to the original app

Related to https://github.com/ahx/openapi_first/issues/410