### PR TITLE
Add after_response_body_property_validation Hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # rspec failure tracking
 .rspec_status
 Gemfile.*.lock
+
+# MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Available hooks:
 - `after_response_validation`
 - `after_request_parameter_property_validation`
 - `after_request_body_property_validation`
+- `after_response_body_property_validation`
 
 Setup per per instance:
 

--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -165,7 +165,10 @@ module OpenapiFirst
       responses.flat_map do |status, response_object|
         headers = build_response_headers(response_object['headers'])
         response_object['content']&.map do |content_type, content_object|
-          content_schema = content_object['schema'].schema(configuration: schemer_configuration)
+          content_schema = content_object['schema'].schema(
+            configuration: schemer_configuration,
+            after_property_validation: config.after_response_body_property_validation
+          )
           Response.new(status:,
                        headers:,
                        content_type:,

--- a/lib/openapi_first/configuration.rb
+++ b/lib/openapi_first/configuration.rb
@@ -8,6 +8,7 @@ module OpenapiFirst
       after_response_validation
       after_request_parameter_property_validation
       after_request_body_property_validation
+      after_response_body_property_validation
     ].freeze
 
     def initialize


### PR DESCRIPTION
Adding a `after_response_body_property_validation` hook that behaves identically to `after_request_body_property_validation`.