### PR TITLE
Support running Test Validation after Request Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # rspec failure tracking
 .rspec_status
 Gemfile.*.lock
+
+# MacOS
+.DS_Store

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -89,9 +89,9 @@ module OpenapiFirst
     # Returns the Rack app wrapped with silent request, response validation
     # You can use this if you want to track coverage via Test::Coverage, but don't want to use
     # the middlewares or manual request, response validation.
-    def self.app(app, spec: nil, api: :default)
+    def self.app(app, spec: nil, api: :default, validate_request_after_handling: false)
       spec ||= self[api]
-      App.new(app, api: spec)
+      App.new(app, api: spec, validate_request_after_handling:)
     end
 
     def self.install

--- a/lib/openapi_first/test/methods.rb
+++ b/lib/openapi_first/test/methods.rb
@@ -12,12 +12,13 @@ module OpenapiFirst
         base.include(AssertionMethod)
       end
 
-      def self.[](application_under_test = nil, api: nil)
+      def self.[](application_under_test = nil, api: nil, validate_request_after_handling: false)
         mod = Module.new do
           def self.included(base)
             base.include OpenapiFirst::Test::Methods::AssertionMethod
           end
         end
+        mod.define_method(:openapi_first_validate_request_after_handling?) { validate_request_after_handling }
 
         if api
           mod.define_method(:openapi_first_default_api) { api }
@@ -26,7 +27,12 @@ module OpenapiFirst
         end
 
         if application_under_test
-          mod.define_method(:app) { OpenapiFirst::Test.app(application_under_test, api: openapi_first_default_api) }
+          mod.define_method(:app) do
+            OpenapiFirst::Test.app(
+              application_under_test, api: openapi_first_default_api,
+                                      validate_request_after_handling: openapi_first_validate_request_after_handling?
+            )
+          end
         end
 
         mod


### PR DESCRIPTION
In a Rails app, there is some data that gets added to the Rack Request `env` by the app itself while the request is handled (such as which controller and action actually handled the request after it was routed).

If you want to access any of this information in any `openapi_first` hooks, than you need to be able to configure tests to do the request validation only after the request has been handled.