### PR TITLE
Test: Track request after calling the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+- Changed OpenapiFirst::Test to track the request _after_ the app has handled the request. See [PR #434](https://github.com/ahx/openapi_first/pull/434). You can restore the old behavior with 
+```ruby
+  include OpenapiFirst::Test::Methods[MyApp, validate_request_before_handling: true]
+```
+
 ### Added
 
 - Added support for a static `path_prefix` value to be set on the creation of a Definition. See [PR #432](https://github.com/ahx/openapi_first/pull/432):

--- a/lib/openapi_first/test.rb
+++ b/lib/openapi_first/test.rb
@@ -95,9 +95,9 @@ module OpenapiFirst
     # Returns the Rack app wrapped with silent request, response validation
     # You can use this if you want to track coverage via Test::Coverage, but don't want to use
     # the middlewares or manual request, response validation.
-    def self.app(app, spec: nil, api: :default, validate_request_after_handling: false)
+    def self.app(app, spec: nil, api: :default, validate_request_before_handling: false)
       spec ||= self[api]
-      App.new(app, api: spec, validate_request_after_handling:)
+      App.new(app, api: spec, validate_request_before_handling:)
     end
 
     def self.install

--- a/lib/openapi_first/test/app.rb
+++ b/lib/openapi_first/test/app.rb
@@ -10,21 +10,21 @@ module OpenapiFirst
     # A wrapper of the original app
     # with silent request/response validation to track requests/responses.
     class App < SimpleDelegator
-      def initialize(app, api:, validate_request_after_handling:)
+      def initialize(app, api:, validate_request_before_handling:)
         super(app)
         @app = app
         @definition = Test[api]
-        @validate_request_after_handling = validate_request_after_handling
+        @validate_request_before_handling = validate_request_before_handling
       end
 
       def call(env)
         request = Rack::Request.new(env)
-        unless @validate_request_after_handling
+        if @validate_request_before_handling
           env[Test::REQUEST] = @definition.validate_request(request, raise_error: false)
         end
 
         response = @app.call(env)
-        if @validate_request_after_handling
+        unless @validate_request_before_handling
           env[Test::REQUEST] = @definition.validate_request(request, raise_error: false)
         end
 

--- a/lib/openapi_first/test/methods.rb
+++ b/lib/openapi_first/test/methods.rb
@@ -12,13 +12,13 @@ module OpenapiFirst
         base.include(AssertionMethod)
       end
 
-      def self.[](application_under_test = nil, api: nil, validate_request_after_handling: false)
+      def self.[](application_under_test = nil, api: nil, validate_request_before_handling: false)
         mod = Module.new do
           def self.included(base)
             base.include OpenapiFirst::Test::Methods::AssertionMethod
           end
         end
-        mod.define_method(:openapi_first_validate_request_after_handling?) { validate_request_after_handling }
+        mod.define_method(:openapi_first_validate_request_before_handling?) { validate_request_before_handling }
 
         if api
           mod.define_method(:openapi_first_default_api) { api }
@@ -30,7 +30,7 @@ module OpenapiFirst
           mod.define_method(:app) do
             OpenapiFirst::Test.app(
               application_under_test, api: openapi_first_default_api,
-                                      validate_request_after_handling: openapi_first_validate_request_after_handling?
+                                      validate_request_before_handling: openapi_first_validate_request_before_handling?
             )
           end
         end

--- a/spec/test/methods_spec.rb
+++ b/spec/test/methods_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe OpenapiFirst::Test::Methods do
     end.to raise_error(OpenapiFirst::Error)
   end
 
+  it 'runs request validation after handling the request' do
+    OpenapiFirst::Test.register('./examples/openapi.yaml')
+    myapp = lambda do |env|
+      expect(env[OpenapiFirst::Test::REQUEST]).to be_nil
+      Rack::Response.new('hello').finish
+    end
+
+    minitest_class = Class.new(Minitest::Test) do
+      include OpenapiFirst::Test::Methods[myapp]
+    end
+
+    expect(minitest_class.included_modules).to include(OpenapiFirst::Test::MinitestHelpers)
+    test_app = minitest_class.new(1).app
+    env = Rack::MockRequest.env_for('/')
+    expect(test_app.call(env)).to eq(Rack::Response.new('hello').finish)
+    expect(env[OpenapiFirst::Test::REQUEST]).to be_valid
+    expect(env[OpenapiFirst::Test::RESPONSE]).to be_a(OpenapiFirst::ValidatedResponse)
+  end
+
   context 'with RSpec' do
     context 'with metadata', api: :v1 do
       include OpenapiFirst::Test::Methods
@@ -88,7 +107,7 @@ RSpec.describe OpenapiFirst::Test::Methods do
   end
 
   context 'with [arguments]' do
-    it 'adds an app method that wraps the default API' do
+    it 'can run validation before handling the request' do
       OpenapiFirst::Test.register('./examples/openapi.yaml')
       myapp = lambda do |env|
         expect(env[OpenapiFirst::Test::REQUEST]).to be_a(OpenapiFirst::ValidatedRequest)
@@ -96,26 +115,7 @@ RSpec.describe OpenapiFirst::Test::Methods do
       end
 
       minitest_class = Class.new(Minitest::Test) do
-        include OpenapiFirst::Test::Methods[myapp]
-      end
-
-      expect(minitest_class.included_modules).to include(OpenapiFirst::Test::MinitestHelpers)
-      test_app = minitest_class.new(1).app
-      env = Rack::MockRequest.env_for('/')
-      expect(test_app.call(env)).to eq(Rack::Response.new('hello').finish)
-      expect(env[OpenapiFirst::Test::REQUEST]).to be_valid
-      expect(env[OpenapiFirst::Test::RESPONSE]).to be_a(OpenapiFirst::ValidatedResponse)
-    end
-
-    it 'can run validation after handling the request, for the default API' do
-      OpenapiFirst::Test.register('./examples/openapi.yaml')
-      myapp = lambda do |env|
-        expect(env[OpenapiFirst::Test::REQUEST]).to be_nil
-        Rack::Response.new('hello').finish
-      end
-
-      minitest_class = Class.new(Minitest::Test) do
-        include OpenapiFirst::Test::Methods[myapp, validate_request_after_handling: true]
+        include OpenapiFirst::Test::Methods[myapp, validate_request_before_handling: true]
       end
 
       expect(minitest_class.included_modules).to include(OpenapiFirst::Test::MinitestHelpers)
@@ -129,7 +129,7 @@ RSpec.describe OpenapiFirst::Test::Methods do
     it 'adds an app method that wraps the app for a specific API' do
       OpenapiFirst::Test.register('./examples/openapi.yaml', as: :v1)
       myapp = lambda do |env|
-        expect(env[OpenapiFirst::Test::REQUEST]).to be_a(OpenapiFirst::ValidatedRequest)
+        expect(env[OpenapiFirst::Test::REQUEST]).to be_nil
         Rack::Response.new('hello').finish
       end
 
@@ -145,15 +145,15 @@ RSpec.describe OpenapiFirst::Test::Methods do
       expect(env[OpenapiFirst::Test::RESPONSE]).to be_a(OpenapiFirst::ValidatedResponse)
     end
 
-    it 'can run validation after handling the request, for a specific API' do
+    it 'can run validation before handling the request, for a specific API' do
       OpenapiFirst::Test.register('./examples/openapi.yaml', as: :v1)
       myapp = lambda do |env|
-        expect(env[OpenapiFirst::Test::REQUEST]).to be_nil
+        expect(env[OpenapiFirst::Test::REQUEST]).to be_a(OpenapiFirst::ValidatedRequest)
         Rack::Response.new('hello').finish
       end
 
       minitest_class = Class.new(Minitest::Test) do
-        include OpenapiFirst::Test::Methods[myapp, api: :v1, validate_request_after_handling: true]
+        include OpenapiFirst::Test::Methods[myapp, api: :v1, validate_request_before_handling: true]
       end
 
       expect(minitest_class.included_modules).to include(OpenapiFirst::Test::MinitestHelpers)


### PR DESCRIPTION
Like https://github.com/ahx/openapi_first/pull/434, but changing to run that as a default

> 
> 
> In a Rails app, there is some data that gets added to the Rack Request env by the app itself while the request is handled (such as which controller and action actually handled the request after it was routed).
> 
> If you want to access any of this information in any openapi_first hooks, than you need to be able to configure tests to do the request validation only after the request has been handled.
> 