### PR TITLE
Guard optional schema in Media Type Objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Fixed: Loading a document no longer raises `NoMethodError: undefined method 'schema' for nil` when a Media Type Object has no `schema` (e.g. it only declares an `example`). `schema` is optional in a Media Type Object; such media types now impose no body-schema constraint.
+
 ## 3.4.2
 
 Fixed: Parsing of JSON-formatted query params [issue #476](https://github.com/ahx/openapi_first/issues/476) (thanks @Drowze)

--- a/lib/openapi_first/builder.rb
+++ b/lib/openapi_first/builder.rb
@@ -140,7 +140,7 @@ module OpenapiFirst
       end
       required_body = operation_object['requestBody']&.resolved&.fetch('required', false) == true
       content_objects.map do |content_type, content_object|
-        content_schema = content_object['schema'].schema(
+        content_schema = content_object['schema']&.schema(
           configuration: schemer_configuration,
           after_property_validation: config.after_request_body_property_validation
         )
@@ -171,7 +171,7 @@ module OpenapiFirst
       responses.flat_map do |status, response_object|
         headers = build_response_headers(response_object['headers'])
         response_object['content']&.map do |content_type, content_object|
-          content_schema = content_object['schema'].schema(
+          content_schema = content_object['schema']&.schema(
             configuration: schemer_configuration,
             after_property_validation: config.after_response_body_property_validation
           )

--- a/spec/data/media-type-without-schema.yaml
+++ b/spec/data/media-type-without-schema.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Media type without schema
+  version: '1.0'
+paths:
+  /thing:
+    post:
+      requestBody:
+        content:
+          application/json:
+            example: '{"name":"foo"}' # valid: media type with example, no schema
+      responses:
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              example: '{"errors":["bad"]}' # valid: media type with example, no schema

--- a/spec/openapi_first_spec.rb
+++ b/spec/openapi_first_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe OpenapiFirst do
       expect(definition.paths).to include('/roles')
     end
 
+    it 'works with a media type that has no schema' do
+      definition = OpenapiFirst.load('./spec/data/media-type-without-schema.yaml')
+      expect(definition.paths).to include('/thing')
+    end
+
     it 'works with YAML' do
       definition = OpenapiFirst.load('./spec/data/petstore.yaml')
       expect(definition.paths).to include('/pets')


### PR DESCRIPTION
A Media Type Object may omit `schema` (e.g. declare only `example`), but the builder called `content_object['schema'].schema(...)` unguarded for both request and response bodies, raising NoMethodError at load time.

Guard with `&.` so a schema-less media type imposes no body-schema constraint, consistent with content-less requests/responses. The request and response validators already short-circuit on a nil content_schema.

Fixes #481